### PR TITLE
Remove ros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ project(${PROJECT_NAME} ${PROJECT_ARGS})
 
 # Project dependencies
 find_package(Eigen3 REQUIRED)
-find_package(roscpp REQUIRED)
 if(BUILD_TESTING)
   find_package(Boost REQUIRED COMPONENTS unit_test_framework)
   if(BUILD_PYTHON_INTERFACE)
@@ -65,12 +64,12 @@ set(${PROJECT_NAME}_HEADERS include/${PROJECT_NAME}/cop_stabilizer.hpp)
 set(${PROJECT_NAME}_SOURCES src/cop_stabilizer.cpp)
 add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES}
                                    ${${PROJECT_NAME}_HEADERS})
-target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen ${roscpp_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 target_include_directories(
   ${PROJECT_NAME}
   PUBLIC $<INSTALL_INTERFACE:include>
-         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> ${roscpp_INCLUDE_DIR}
-         ${roscpp_INCLUDE_DIRS})
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+         )
 if(SUFFIX_SO_VERSION)
   set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,8 @@ add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES}
                                    ${${PROJECT_NAME}_HEADERS})
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 target_include_directories(
-  ${PROJECT_NAME}
-  PUBLIC $<INSTALL_INTERFACE:include>
-         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-         )
+  ${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:include>
+                         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>)
 if(SUFFIX_SO_VERSION)
   set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION})
 endif()

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
   <build_depend>Eigen3</build_depend>
-  <build_depend>roscpp</build_depend>
   <!-- The following tags are recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -280,7 +280,6 @@ void CopStabilizer::stabilizeCOP(  // Not supported
     computeSupportPolygon(actual_stance_poses, support_polygon_);
 
     if (!isPointInPolygon(COP_unclamped, support_polygon_)) {
-
       eVector2 COP_clamped;
       projectCOPinSupportPolygon(COP_unclamped, support_polygon_, COP_clamped);
 

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -1,7 +1,6 @@
 #include "biped-stabilizer/cop_stabilizer.hpp"
 
 #include "biped-stabilizer/third_party/wykobi/wykobi_algorithm.hpp"
-#include "ros/ros.h"
 
 namespace biped_stabilizer {
 
@@ -26,7 +25,6 @@ CopStabilizer::~CopStabilizer() {}
 void CopStabilizer::configure(const CopStabilizerSettings &settings) {
   settings_ = settings;
   const double &dt = settings_.dt;
-  ROS_INFO_STREAM("Calling CopStabilizer::configure with dt = " << dt);
   configured_ = true;
   first_iter_ = true;
   w2_ = settings_.g / settings_.height;
@@ -282,7 +280,6 @@ void CopStabilizer::stabilizeCOP(  // Not supported
     computeSupportPolygon(actual_stance_poses, support_polygon_);
 
     if (!isPointInPolygon(COP_unclamped, support_polygon_)) {
-      ROS_INFO("Stabilize: unclamped COP not in the support polygon");
 
       eVector2 COP_clamped;
       projectCOPinSupportPolygon(COP_unclamped, support_polygon_, COP_clamped);
@@ -312,7 +309,6 @@ void CopStabilizer::stabilizeCOP(  // Not supported
 
       nextState_x = nextRefState_x + nextStateTrackingError_clamped_x;
       nextState_y = nextRefState_y + nextStateTrackingError_clamped_y;
-      ROS_INFO_STREAM("non linear part: " << non_linear_);
     }
   }
 
@@ -470,7 +466,6 @@ void CopStabilizer::stabilizeP_CC(
 
   if (first_iter_) {
     first_iter_ = false;
-    ROS_INFO_STREAM("First COM target : " << target_com_.transpose());
   }
   // REFERENCE
   const Eigen::Vector2d referenceCCOP(reference_com.head<2>() -


### PR DESCRIPTION
@nim65s Roscpp was only used for printing outputs. Maybe there is still some useless lines in the package.xml now but I wasn't sure if I could remove them.