### PR TITLE
Change Eigen3 -> eigen in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
 
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
-  <build_depend>Eigen3</build_depend>
+  <build_depend>eigen</build_depend>
   <!-- The following tags are recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>


### PR DESCRIPTION
rosdep don't have rule for Eigen3, eigen point to Eigen3 by default. This is the syntax used in the other packages of Gepetto also.