### PR TITLE
All CoP variables in public API are now vector2 (instead of vector3)

### DIFF
--- a/include/biped-stabilizer/cop_stabilizer.hpp
+++ b/include/biped-stabilizer/cop_stabilizer.hpp
@@ -48,7 +48,7 @@ public:
   bool saturate_cop = true;
   bool use_rate_limited_dcm = false;
 
-  bool operator==(const CopStabilizerSettings& rhs) {
+  bool operator==(const CopStabilizerSettings &rhs) {
     bool test = true;
     test &= this->height == rhs.height;
     test &= this->foot_length == rhs.foot_length;
@@ -65,7 +65,7 @@ public:
     return test;
   }
 
-  bool operator!=(const CopStabilizerSettings& rhs) { return !(*this == rhs); }
+  bool operator!=(const CopStabilizerSettings &rhs) { return !(*this == rhs); }
 
   std::string to_string() {
     std::ostringstream oss;
@@ -88,7 +88,7 @@ public:
     return oss.str();
   }
 
-  std::ostream& operator<<(std::ostream& out) {
+  std::ostream &operator<<(std::ostream &out) {
     out << this->to_string();
     return out;
   }
@@ -105,13 +105,13 @@ public:
    * @param settings the settings for the CoP stabilizer, see
    * CopStabilizerSettings.
    */
-  CopStabilizer(const CopStabilizerSettings& settings);
+  CopStabilizer(const CopStabilizerSettings &settings);
 
   virtual ~CopStabilizer();
 
-  virtual void configure(const CopStabilizerSettings & settings);
+  virtual void configure(const CopStabilizerSettings &settings);
 
-  const CopStabilizerSettings& getSettings() { return settings_; }
+  const CopStabilizerSettings &getSettings() { return settings_; }
 
   [[deprecated("The usage of the eVector3 for the CoP is deprecated, use "
                "the eVector2 version instead.")]]
@@ -199,111 +199,111 @@ public:
                      eVector3 &actual_icp,            // ???
                      eVector3 &desired_cop_reference, // ???
                      eVector3 &desired_cop_computed);
-  
+
   [[deprecated("The usage of the eVector3 for the CoP is deprecated, use "
                "the eVector2 version instead.")]]
-  double distributeForces(const eVector3& desired_cop, const eVector2 LF_xy,
+  double distributeForces(const eVector3 &desired_cop, const eVector2 LF_xy,
                           const double LF_force_z, const eVector2 LF_torque_xy,
                           const eVector2 RF_xy, const double RF_force_z,
                           const eVector2 RF_torque_xy);
 
-  void stabilize(const eVector3& actual_com, const eVector3& actual_com_vel,
-                 const eVector3& actual_com_acc, const eVector2& actual_cop,
-                 const eMatrixHoms& actual_stance_poses,
-                 const eVector3& reference_com,
-                 const eVector3& reference_com_vel,
-                 const eVector3& reference_com_acc,
-                 const eVector3& reference_com_jerk, eVector3& desired_com,
-                 eVector3& desired_com_vel, eVector3& desired_com_acc,
-                 eVector3& desired_icp,            // ???
-                 eVector3& actual_icp,             // ???
-                 eVector2& desired_cop_reference,  // ???
-                 eVector2& desired_cop_computed);
+  void stabilize(const eVector3 &actual_com, const eVector3 &actual_com_vel,
+                 const eVector3 &actual_com_acc, const eVector2 &actual_cop,
+                 const eMatrixHoms &actual_stance_poses,
+                 const eVector3 &reference_com,
+                 const eVector3 &reference_com_vel,
+                 const eVector3 &reference_com_acc,
+                 const eVector3 &reference_com_jerk, eVector3 &desired_com,
+                 eVector3 &desired_com_vel, eVector3 &desired_com_acc,
+                 eVector3 &desired_icp,           // ???
+                 eVector3 &actual_icp,            // ???
+                 eVector2 &desired_cop_reference, // ???
+                 eVector2 &desired_cop_computed);
 
-  void stabilize(const eVector3& actual_com, const eVector3& actual_com_vel,
-                 const eVector3& actual_com_acc, const eVector2& actual_cop,
-                 const Polygon2D& support_polygon,
-                 const eVector3& reference_com,
-                 const eVector3& reference_com_vel,
-                 const eVector3& reference_com_acc,
-                 const eVector3& reference_com_jerk, eVector3& desired_com,
-                 eVector3& desired_com_vel, eVector3& desired_com_acc,
-                 eVector3& desired_icp,            // ???
-                 eVector3& actual_icp,             // ???
-                 eVector2& desired_cop_reference,  // ???
-                 eVector2& desired_cop_computed);
+  void stabilize(const eVector3 &actual_com, const eVector3 &actual_com_vel,
+                 const eVector3 &actual_com_acc, const eVector2 &actual_cop,
+                 const Polygon2D &support_polygon,
+                 const eVector3 &reference_com,
+                 const eVector3 &reference_com_vel,
+                 const eVector3 &reference_com_acc,
+                 const eVector3 &reference_com_jerk, eVector3 &desired_com,
+                 eVector3 &desired_com_vel, eVector3 &desired_com_acc,
+                 eVector3 &desired_icp,           // ???
+                 eVector3 &actual_icp,            // ???
+                 eVector2 &desired_cop_reference, // ???
+                 eVector2 &desired_cop_computed);
 
-  void stabilizeCOP(const eVector3& actual_com, const eVector3& actual_com_vel,
-                    const eVector3& actual_com_acc, const eVector2& actual_cop,
-                    const Polygon2D& support_polygon,
-                    const eVector3& reference_com,
-                    const eVector3& reference_com_vel,
-                    const eVector3& reference_com_acc, eVector3& desired_com,
-                    eVector3& desired_com_vel, eVector3& desired_com_acc,
-                    eVector3& desired_icp,            // ???
-                    eVector3& actual_icp,             // ???
-                    eVector2& desired_cop_reference,  // ???
-                    eVector2& desired_cop_computed);
+  void stabilizeCOP(const eVector3 &actual_com, const eVector3 &actual_com_vel,
+                    const eVector3 &actual_com_acc, const eVector2 &actual_cop,
+                    const Polygon2D &support_polygon,
+                    const eVector3 &reference_com,
+                    const eVector3 &reference_com_vel,
+                    const eVector3 &reference_com_acc, eVector3 &desired_com,
+                    eVector3 &desired_com_vel, eVector3 &desired_com_acc,
+                    eVector3 &desired_icp,           // ???
+                    eVector3 &actual_icp,            // ???
+                    eVector2 &desired_cop_reference, // ???
+                    eVector2 &desired_cop_computed);
 
   void stabilizeApproximateAcceleration(
-      const eVector3& actual_com, const eVector3& actual_com_vel,
-      const eVector3& actual_com_acc, const eVector2& actual_cop,
-      const Polygon2D& support_polygon, const eVector3& reference_com,
-      const eVector3& reference_com_vel, const eVector3& reference_com_acc,
-      eVector3& desired_com, eVector3& desired_com_vel,
-      eVector3& desired_com_acc,
-      eVector3& desired_icp,            // ???
-      eVector3& actual_icp,             // ???
-      eVector2& desired_cop_reference,  // ???
-      eVector2& desired_cop_computed);
+      const eVector3 &actual_com, const eVector3 &actual_com_vel,
+      const eVector3 &actual_com_acc, const eVector2 &actual_cop,
+      const Polygon2D &support_polygon, const eVector3 &reference_com,
+      const eVector3 &reference_com_vel, const eVector3 &reference_com_acc,
+      eVector3 &desired_com, eVector3 &desired_com_vel,
+      eVector3 &desired_com_acc,
+      eVector3 &desired_icp,           // ???
+      eVector3 &actual_icp,            // ???
+      eVector2 &desired_cop_reference, // ???
+      eVector2 &desired_cop_computed);
 
-  void stabilizeP_CC(const eVector3& actual_com, const eVector3& actual_com_vel,
-                     const eVector3& actual_com_acc, const eVector2& actual_cop,
-                     const Polygon2D& support_polygon,
-                     const eVector3& reference_com,
-                     const eVector3& reference_com_vel,
-                     const eVector3& reference_com_acc, eVector3& desired_com,
-                     eVector3& desired_com_vel, eVector3& desired_com_acc,
-                     eVector3& desired_icp,            // ???
-                     eVector3& actual_icp,             // ???
-                     eVector2& desired_cop_reference,  // ???
-                     eVector2& desired_cop_computed);
+  void stabilizeP_CC(const eVector3 &actual_com, const eVector3 &actual_com_vel,
+                     const eVector3 &actual_com_acc, const eVector2 &actual_cop,
+                     const Polygon2D &support_polygon,
+                     const eVector3 &reference_com,
+                     const eVector3 &reference_com_vel,
+                     const eVector3 &reference_com_acc, eVector3 &desired_com,
+                     eVector3 &desired_com_vel, eVector3 &desired_com_acc,
+                     eVector3 &desired_icp,           // ???
+                     eVector3 &actual_icp,            // ???
+                     eVector2 &desired_cop_reference, // ???
+                     eVector2 &desired_cop_computed);
 
-  void stabilizeJerk(const eVector3& actual_com, const eVector3& actual_com_vel,
-                     const eVector3& actual_com_acc, const eVector2& actual_cop,
-                     const Polygon2D& support_polygon,
-                     const eVector3& reference_com,
-                     const eVector3& reference_com_vel,
-                     const eVector3& reference_com_acc,
-                     const eVector3& reference_com_jerk, eVector3& desired_com,
-                     eVector3& desired_com_vel, eVector3& desired_com_acc,
-                     eVector3& desired_icp,            // ???
-                     eVector3& actual_icp,             // ???
-                     eVector2& desired_cop_reference,  // ???
-                     eVector2& desired_cop_computed);
+  void stabilizeJerk(const eVector3 &actual_com, const eVector3 &actual_com_vel,
+                     const eVector3 &actual_com_acc, const eVector2 &actual_cop,
+                     const Polygon2D &support_polygon,
+                     const eVector3 &reference_com,
+                     const eVector3 &reference_com_vel,
+                     const eVector3 &reference_com_acc,
+                     const eVector3 &reference_com_jerk, eVector3 &desired_com,
+                     eVector3 &desired_com_vel, eVector3 &desired_com_acc,
+                     eVector3 &desired_icp,           // ???
+                     eVector3 &actual_icp,            // ???
+                     eVector2 &desired_cop_reference, // ???
+                     eVector2 &desired_cop_computed);
 
-  double distributeForces(const eVector2& desired_cop, const eVector2 LF_xy,
+  double distributeForces(const eVector2 &desired_cop, const eVector2 LF_xy,
                           const double LF_force_z, const eVector2 LF_torque_xy,
                           const eVector2 RF_xy, const double RF_force_z,
                           const eVector2 RF_torque_xy);
 
-  std::array<eVector3, 3> getStableCoMs(const double& com_height);
+  std::array<eVector3, 3> getStableCoMs(const double &com_height);
 
-  void setCOPgains(const eVector3& cop_x_gains, const eVector3& cop_y_gains);
+  void setCOPgains(const eVector3 &cop_x_gains, const eVector3 &cop_y_gains);
 
   void setPCCgains(const double cop_pcc_gains);
 
-  void setIntegralGains(const eVector2& integral_gains);
+  void setIntegralGains(const eVector2 &integral_gains);
 
 private:
   void computeSupportPolygon(const eMatrixHoms &stance_poses,
                              Polygon2D &convex_hull);
 
-  void projectCOPinSupportPolygon(const eVector2& target_cop_unclamped,
-                                  const Polygon2D& polygon,
-                                  eVector2& target_cop);
+  void projectCOPinSupportPolygon(const eVector2 &target_cop_unclamped,
+                                  const Polygon2D &polygon,
+                                  eVector2 &target_cop);
 
-  bool isPointInPolygon(const eVector2& point, const Polygon2D& polygon);
+  bool isPointInPolygon(const eVector2 &point, const Polygon2D &polygon);
 
   /**
    * @brief getActualCOM_acc compute COM acceleration from the contact forces
@@ -313,7 +313,7 @@ private:
    * gravity and ground contact forces.
    * @return the COM acceleration
    */
-  Eigen::Vector3d getActualCOM_acc(const Eigen::Vector3d& externalForce);
+  Eigen::Vector3d getActualCOM_acc(const Eigen::Vector3d &externalForce);
 
   /**
    * @brief movingAverage Insert x at the beginning of the queue, remove all the
@@ -325,41 +325,41 @@ private:
    * @return
    */
   template <typename T, typename vec_T>
-  T movingAverage(const T x, const unsigned long nb_samples, vec_T& queue);
+  T movingAverage(const T x, const unsigned long nb_samples, vec_T &queue);
 
-  void getNonLinearPart(const eVector6& leftFootWrench,
-                        const eVector6& rightFootWrench,
-                        const Eigen::Vector2d& leftFootPlace,
-                        const Eigen::Vector2d& rightFootPlace,
-                        const Eigen::Vector2d& CoM,
-                        const Eigen::Vector2d& lateral_gravity,
-                        const Eigen::Vector2d& externalForce, eVector3& n);
+  void getNonLinearPart(const eVector6 &leftFootWrench,
+                        const eVector6 &rightFootWrench,
+                        const Eigen::Vector2d &leftFootPlace,
+                        const Eigen::Vector2d &rightFootPlace,
+                        const Eigen::Vector2d &CoM,
+                        const Eigen::Vector2d &lateral_gravity,
+                        const Eigen::Vector2d &externalForce, eVector3 &n);
 
-  void getNonLinearPart(const eVector6& leftFootWrench,
-                        const eVector6& rightFootWrench,
-                        const Eigen::Vector2d& leftFootPlace,
-                        const Eigen::Vector2d& rightFootPlace,
-                        const Eigen::Vector2d& CoM,
-                        const Eigen::Vector2d& CoM_acc, eVector3& n);
+  void getNonLinearPart(const eVector6 &leftFootWrench,
+                        const eVector6 &rightFootWrench,
+                        const Eigen::Vector2d &leftFootPlace,
+                        const Eigen::Vector2d &rightFootPlace,
+                        const Eigen::Vector2d &CoM,
+                        const Eigen::Vector2d &CoM_acc, eVector3 &n);
 
-  void getNonLinearPart(const eVector6& leftFootWrench,
-                        const eVector6& rightFootWrench,
-                        const Eigen::Vector2d& leftFootPlace_c,
-                        const Eigen::Vector2d& rightFootPlace_c,
-                        const Eigen::Vector2d& CoM_acc, eVector3& n);
+  void getNonLinearPart(const eVector6 &leftFootWrench,
+                        const eVector6 &rightFootWrench,
+                        const Eigen::Vector2d &leftFootPlace_c,
+                        const Eigen::Vector2d &rightFootPlace_c,
+                        const Eigen::Vector2d &CoM_acc, eVector3 &n);
 
-  void getNonLinearPart(const eVector3& com, const eVector3& com_acc,
-                        const eVector2& cop, eVector3& n);
+  void getNonLinearPart(const eVector3 &com, const eVector3 &com_acc,
+                        const eVector2 &cop, eVector3 &n);
 
-  void getNonLinearPart(eVector3& n);
+  void getNonLinearPart(eVector3 &n);
 
-  double estimateCopDisturbance(const eVector2& currentTrackingError,
-                                eVector2& oldTrackingError,
-                                const eVector2& c_gainK);
+  double estimateCopDisturbance(const eVector2 &currentTrackingError,
+                                eVector2 &oldTrackingError,
+                                const eVector2 &c_gainK);
 
-  double estimateJerkDisturbance(const eVector3& currentTrackingError,
-                                 eVector3& oldTrackingError,
-                                 const eVector3& c_gainK);
+  double estimateJerkDisturbance(const eVector3 &currentTrackingError,
+                                 eVector3 &oldTrackingError,
+                                 const eVector3 &c_gainK);
 
   bool configured_, first_iter_;
   eMatrixRot A_, Aj_;
@@ -404,7 +404,7 @@ private:
   // Input settings.
   CopStabilizerSettings settings_;
 
- protected:
+protected:
   Eigen::Vector3d target_com_, target_com_vel_, target_com_acc_,
       target_com_jerk_, non_linear_;
   eVector2 target_cop_, desired_uncampled_cop_;

--- a/include/biped-stabilizer/cop_stabilizer.hpp
+++ b/include/biped-stabilizer/cop_stabilizer.hpp
@@ -109,7 +109,7 @@ public:
 
   virtual ~CopStabilizer();
 
-  void configure(const CopStabilizerSettings& settings);
+  virtual void configure(const CopStabilizerSettings & settings);
 
   const CopStabilizerSettings& getSettings() { return settings_; }
 

--- a/include/biped-stabilizer/cop_stabilizer.hpp
+++ b/include/biped-stabilizer/cop_stabilizer.hpp
@@ -113,6 +113,8 @@ public:
 
   const CopStabilizerSettings& getSettings() { return settings_; }
 
+  [[deprecated("The usage of the eVector3 for the CoP is deprecated, use "
+               "the eVector2 version instead.")]]
   void stabilize(const eVector3 &actual_com, const eVector3 &actual_com_vel,
                  const eVector3 &actual_com_acc, const eVector3 &actual_cop,
                  const eMatrixHoms &actual_stance_poses,
@@ -126,6 +128,8 @@ public:
                  eVector3 &desired_cop_reference, // ???
                  eVector3 &desired_cop_computed);
 
+  [[deprecated("The usage of the eVector3 for the CoP is deprecated, use "
+               "the eVector2 version instead.")]]
   void stabilize(const eVector3 &actual_com, const eVector3 &actual_com_vel,
                  const eVector3 &actual_com_acc, const eVector3 &actual_cop,
                  const Polygon2D &support_polygon,
@@ -139,6 +143,8 @@ public:
                  eVector3 &desired_cop_reference, // ???
                  eVector3 &desired_cop_computed);
 
+  [[deprecated("The usage of the eVector3 for the CoP is deprecated, use "
+               "the eVector2 version instead.")]]
   void stabilizeCOP(const eVector3 &actual_com, const eVector3 &actual_com_vel,
                     const eVector3 &actual_com_acc, const eVector3 &actual_cop,
                     const Polygon2D &support_polygon,
@@ -151,6 +157,8 @@ public:
                     eVector3 &desired_cop_reference, // ???
                     eVector3 &desired_cop_computed);
 
+  [[deprecated("The usage of the eVector3 for the CoP is deprecated, use "
+               "the eVector2 version instead.")]]
   void stabilizeApproximateAcceleration(
       const eVector3 &actual_com, const eVector3 &actual_com_vel,
       const eVector3 &actual_com_acc, const eVector3 &actual_cop,
@@ -163,6 +171,8 @@ public:
       eVector3 &desired_cop_reference, // ???
       eVector3 &desired_cop_computed);
 
+  [[deprecated("The usage of the eVector3 for the CoP is deprecated, use "
+               "the eVector2 version instead.")]]
   void stabilizeP_CC(const eVector3 &actual_com, const eVector3 &actual_com_vel,
                      const eVector3 &actual_com_acc, const eVector3 &actual_cop,
                      const Polygon2D &support_polygon,
@@ -175,6 +185,8 @@ public:
                      eVector3 &desired_cop_reference, // ???
                      eVector3 &desired_cop_computed);
 
+  [[deprecated("The usage of the eVector3 for the CoP is deprecated, use "
+               "the eVector2 version instead.")]]
   void stabilizeJerk(const eVector3 &actual_com, const eVector3 &actual_com_vel,
                      const eVector3 &actual_com_acc, const eVector3 &actual_cop,
                      const Polygon2D &support_polygon,
@@ -187,19 +199,14 @@ public:
                      eVector3 &actual_icp,            // ???
                      eVector3 &desired_cop_reference, // ???
                      eVector3 &desired_cop_computed);
-  void stabilize(
-    const eVector3 & actual_com, const eVector3 & actual_com_vel,
-    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
-    const eMatrixHoms & actual_stance_poses,
-    const eVector3 & reference_com,
-    const eVector3 & reference_com_vel,
-    const eVector3 & reference_com_acc,
-    const eVector3 & reference_com_jerk, eVector3 & desired_com,
-    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
-    eVector3 & desired_icp,                        // ???
-    eVector3 & actual_icp,                         // ???
-    eVector2 & desired_cop_reference,              // ???
-    eVector2 & desired_cop_computed);
+  
+  [[deprecated("The usage of the eVector3 for the CoP is deprecated, use "
+               "the eVector2 version instead.")]]
+  double distributeForces(const eVector3& desired_cop, const eVector2 LF_xy,
+                          const double LF_force_z, const eVector2 LF_torque_xy,
+                          const eVector2 RF_xy, const double RF_force_z,
+                          const eVector2 RF_torque_xy);
+
   void stabilize(const eVector3& actual_com, const eVector3& actual_com_vel,
                  const eVector3& actual_com_acc, const eVector2& actual_cop,
                  const eMatrixHoms& actual_stance_poses,

--- a/include/biped-stabilizer/cop_stabilizer.hpp
+++ b/include/biped-stabilizer/cop_stabilizer.hpp
@@ -15,8 +15,7 @@
 
 #include "biped-stabilizer/third_party/wykobi/wykobi.hpp"
 
-namespace biped_stabilizer
-{
+namespace biped_stabilizer {
 
 typedef wykobi::polygon<double, 2> Polygon2D;
 typedef Eigen::Matrix<double, 2, 1> eVector2;
@@ -25,7 +24,7 @@ typedef Eigen::Matrix<double, 6, 1> eVector6;
 typedef Eigen::Isometry3d eMatrixHom;
 typedef Eigen::Matrix3d eMatrixRot;
 typedef std::vector<eMatrixHom, Eigen::aligned_allocator<eMatrixHom>>
-  eMatrixHoms;
+    eMatrixHoms;
 typedef std::vector<eVector2, Eigen::aligned_allocator<eVector2>> eVector2s;
 typedef std::vector<eVector3, Eigen::aligned_allocator<eVector3>> eVector3s;
 
@@ -49,8 +48,7 @@ public:
   bool saturate_cop = true;
   bool use_rate_limited_dcm = false;
 
-  bool operator==(const CopStabilizerSettings & rhs)
-  {
+  bool operator==(const CopStabilizerSettings& rhs) {
     bool test = true;
     test &= this->height == rhs.height;
     test &= this->foot_length == rhs.foot_length;
@@ -67,10 +65,9 @@ public:
     return test;
   }
 
-  bool operator!=(const CopStabilizerSettings & rhs) {return !(*this == rhs);}
+  bool operator!=(const CopStabilizerSettings& rhs) { return !(*this == rhs); }
 
-  std::string to_string()
-  {
+  std::string to_string() {
     std::ostringstream oss;
     oss << "CopStabilizerSettings:" << std::endl;
     oss << "    - height = " << this->height << std::endl;
@@ -91,8 +88,7 @@ public:
     return oss.str();
   }
 
-  std::ostream & operator<<(std::ostream & out)
-  {
+  std::ostream& operator<<(std::ostream& out) {
     out << this->to_string();
     return out;
   }
@@ -106,15 +102,16 @@ public:
 
   /**
    * @brief CopStabilizer stabilize the CoP around a reference point.
-   * @param settings the settings for the CoP stabilizer, see CopStabilizerSettings.
+   * @param settings the settings for the CoP stabilizer, see
+   * CopStabilizerSettings.
    */
-  CopStabilizer(const CopStabilizerSettings & settings);
+  CopStabilizer(const CopStabilizerSettings& settings);
 
   virtual ~CopStabilizer();
 
-  void configure(const CopStabilizerSettings & settings);
+  void configure(const CopStabilizerSettings& settings);
 
-  const CopStabilizerSettings & getSettings() {return settings_;}
+  const CopStabilizerSettings& getSettings() { return settings_; }
 
   void stabilize(const eVector3 &actual_com, const eVector3 &actual_com_vel,
                  const eVector3 &actual_com_acc, const eVector3 &actual_cop,
@@ -203,97 +200,103 @@ public:
     eVector3 & actual_icp,                         // ???
     eVector2 & desired_cop_reference,              // ???
     eVector2 & desired_cop_computed);
+  void stabilize(const eVector3& actual_com, const eVector3& actual_com_vel,
+                 const eVector3& actual_com_acc, const eVector2& actual_cop,
+                 const eMatrixHoms& actual_stance_poses,
+                 const eVector3& reference_com,
+                 const eVector3& reference_com_vel,
+                 const eVector3& reference_com_acc,
+                 const eVector3& reference_com_jerk, eVector3& desired_com,
+                 eVector3& desired_com_vel, eVector3& desired_com_acc,
+                 eVector3& desired_icp,            // ???
+                 eVector3& actual_icp,             // ???
+                 eVector2& desired_cop_reference,  // ???
+                 eVector2& desired_cop_computed);
 
-  void stabilize(
-    const eVector3 & actual_com, const eVector3 & actual_com_vel,
-    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
-    const Polygon2D & support_polygon,
-    const eVector3 & reference_com,
-    const eVector3 & reference_com_vel,
-    const eVector3 & reference_com_acc,
-    const eVector3 & reference_com_jerk, eVector3 & desired_com,
-    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
-    eVector3 & desired_icp,                        // ???
-    eVector3 & actual_icp,                         // ???
-    eVector2 & desired_cop_reference,              // ???
-    eVector2 & desired_cop_computed);
+  void stabilize(const eVector3& actual_com, const eVector3& actual_com_vel,
+                 const eVector3& actual_com_acc, const eVector2& actual_cop,
+                 const Polygon2D& support_polygon,
+                 const eVector3& reference_com,
+                 const eVector3& reference_com_vel,
+                 const eVector3& reference_com_acc,
+                 const eVector3& reference_com_jerk, eVector3& desired_com,
+                 eVector3& desired_com_vel, eVector3& desired_com_acc,
+                 eVector3& desired_icp,            // ???
+                 eVector3& actual_icp,             // ???
+                 eVector2& desired_cop_reference,  // ???
+                 eVector2& desired_cop_computed);
 
-  void stabilizeCOP(
-    const eVector3 & actual_com, const eVector3 & actual_com_vel,
-    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
-    const Polygon2D & support_polygon,
-    const eVector3 & reference_com,
-    const eVector3 & reference_com_vel,
-    const eVector3 & reference_com_acc, eVector3 & desired_com,
-    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
-    eVector3 & desired_icp,                           // ???
-    eVector3 & actual_icp,                            // ???
-    eVector2 & desired_cop_reference,                 // ???
-    eVector2 & desired_cop_computed);
+  void stabilizeCOP(const eVector3& actual_com, const eVector3& actual_com_vel,
+                    const eVector3& actual_com_acc, const eVector2& actual_cop,
+                    const Polygon2D& support_polygon,
+                    const eVector3& reference_com,
+                    const eVector3& reference_com_vel,
+                    const eVector3& reference_com_acc, eVector3& desired_com,
+                    eVector3& desired_com_vel, eVector3& desired_com_acc,
+                    eVector3& desired_icp,            // ???
+                    eVector3& actual_icp,             // ???
+                    eVector2& desired_cop_reference,  // ???
+                    eVector2& desired_cop_computed);
 
   void stabilizeApproximateAcceleration(
-    const eVector3 & actual_com, const eVector3 & actual_com_vel,
-    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
-    const Polygon2D & support_polygon, const eVector3 & reference_com,
-    const eVector3 & reference_com_vel, const eVector3 & reference_com_acc,
-    eVector3 & desired_com, eVector3 & desired_com_vel,
-    eVector3 & desired_com_acc,
-    eVector3 & desired_icp,             // ???
-    eVector3 & actual_icp,              // ???
-    eVector2 & desired_cop_reference,   // ???
-    eVector2 & desired_cop_computed);
+      const eVector3& actual_com, const eVector3& actual_com_vel,
+      const eVector3& actual_com_acc, const eVector2& actual_cop,
+      const Polygon2D& support_polygon, const eVector3& reference_com,
+      const eVector3& reference_com_vel, const eVector3& reference_com_acc,
+      eVector3& desired_com, eVector3& desired_com_vel,
+      eVector3& desired_com_acc,
+      eVector3& desired_icp,            // ???
+      eVector3& actual_icp,             // ???
+      eVector2& desired_cop_reference,  // ???
+      eVector2& desired_cop_computed);
 
-  void stabilizeP_CC(
-    const eVector3 & actual_com, const eVector3 & actual_com_vel,
-    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
-    const Polygon2D & support_polygon,
-    const eVector3 & reference_com,
-    const eVector3 & reference_com_vel,
-    const eVector3 & reference_com_acc, eVector3 & desired_com,
-    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
-    eVector3 & desired_icp,                            // ???
-    eVector3 & actual_icp,                             // ???
-    eVector2 & desired_cop_reference,                  // ???
-    eVector2 & desired_cop_computed);
+  void stabilizeP_CC(const eVector3& actual_com, const eVector3& actual_com_vel,
+                     const eVector3& actual_com_acc, const eVector2& actual_cop,
+                     const Polygon2D& support_polygon,
+                     const eVector3& reference_com,
+                     const eVector3& reference_com_vel,
+                     const eVector3& reference_com_acc, eVector3& desired_com,
+                     eVector3& desired_com_vel, eVector3& desired_com_acc,
+                     eVector3& desired_icp,            // ???
+                     eVector3& actual_icp,             // ???
+                     eVector2& desired_cop_reference,  // ???
+                     eVector2& desired_cop_computed);
 
-  void stabilizeJerk(
-    const eVector3 & actual_com, const eVector3 & actual_com_vel,
-    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
-    const Polygon2D & support_polygon,
-    const eVector3 & reference_com,
-    const eVector3 & reference_com_vel,
-    const eVector3 & reference_com_acc,
-    const eVector3 & reference_com_jerk, eVector3 & desired_com,
-    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
-    eVector3 & desired_icp,                            // ???
-    eVector3 & actual_icp,                             // ???
-    eVector2 & desired_cop_reference,                  // ???
-    eVector2 & desired_cop_computed);
+  void stabilizeJerk(const eVector3& actual_com, const eVector3& actual_com_vel,
+                     const eVector3& actual_com_acc, const eVector2& actual_cop,
+                     const Polygon2D& support_polygon,
+                     const eVector3& reference_com,
+                     const eVector3& reference_com_vel,
+                     const eVector3& reference_com_acc,
+                     const eVector3& reference_com_jerk, eVector3& desired_com,
+                     eVector3& desired_com_vel, eVector3& desired_com_acc,
+                     eVector3& desired_icp,            // ???
+                     eVector3& actual_icp,             // ???
+                     eVector2& desired_cop_reference,  // ???
+                     eVector2& desired_cop_computed);
 
-  double distributeForces(
-    const eVector2 & desired_cop, const eVector2 LF_xy,
-    const double LF_force_z, const eVector2 LF_torque_xy,
-    const eVector2 RF_xy, const double RF_force_z,
-    const eVector2 RF_torque_xy);
+  double distributeForces(const eVector2& desired_cop, const eVector2 LF_xy,
+                          const double LF_force_z, const eVector2 LF_torque_xy,
+                          const eVector2 RF_xy, const double RF_force_z,
+                          const eVector2 RF_torque_xy);
 
-  std::array<eVector3, 3> getStableCoMs(const double & com_height);
+  std::array<eVector3, 3> getStableCoMs(const double& com_height);
 
-  void setCOPgains(const eVector3 & cop_x_gains, const eVector3 & cop_y_gains);
+  void setCOPgains(const eVector3& cop_x_gains, const eVector3& cop_y_gains);
 
   void setPCCgains(const double cop_pcc_gains);
 
-  void setIntegralGains(const eVector2 & integral_gains);
+  void setIntegralGains(const eVector2& integral_gains);
 
 private:
   void computeSupportPolygon(const eMatrixHoms &stance_poses,
                              Polygon2D &convex_hull);
 
-  void projectCOPinSupportPolygon(
-    const eVector2 & target_cop_unclamped,
-    const Polygon2D & polygon,
-    eVector2 & target_cop);
+  void projectCOPinSupportPolygon(const eVector2& target_cop_unclamped,
+                                  const Polygon2D& polygon,
+                                  eVector2& target_cop);
 
-  bool isPointInPolygon(const eVector2 & point, const Polygon2D & polygon);
+  bool isPointInPolygon(const eVector2& point, const Polygon2D& polygon);
 
   /**
    * @brief getActualCOM_acc compute COM acceleration from the contact forces
@@ -303,7 +306,7 @@ private:
    * gravity and ground contact forces.
    * @return the COM acceleration
    */
-  Eigen::Vector3d getActualCOM_acc(const Eigen::Vector3d & externalForce);
+  Eigen::Vector3d getActualCOM_acc(const Eigen::Vector3d& externalForce);
 
   /**
    * @brief movingAverage Insert x at the beginning of the queue, remove all the
@@ -314,48 +317,42 @@ private:
    * @param MA_queue
    * @return
    */
-  template<typename T, typename vec_T>
-  T movingAverage(const T x, const unsigned long nb_samples, vec_T & queue);
+  template <typename T, typename vec_T>
+  T movingAverage(const T x, const unsigned long nb_samples, vec_T& queue);
 
-  void getNonLinearPart(
-    const eVector6 & leftFootWrench,
-    const eVector6 & rightFootWrench,
-    const Eigen::Vector2d & leftFootPlace,
-    const Eigen::Vector2d & rightFootPlace,
-    const Eigen::Vector2d & CoM,
-    const Eigen::Vector2d & lateral_gravity,
-    const Eigen::Vector2d & externalForce, eVector3 & n);
+  void getNonLinearPart(const eVector6& leftFootWrench,
+                        const eVector6& rightFootWrench,
+                        const Eigen::Vector2d& leftFootPlace,
+                        const Eigen::Vector2d& rightFootPlace,
+                        const Eigen::Vector2d& CoM,
+                        const Eigen::Vector2d& lateral_gravity,
+                        const Eigen::Vector2d& externalForce, eVector3& n);
 
-  void getNonLinearPart(
-    const eVector6 & leftFootWrench,
-    const eVector6 & rightFootWrench,
-    const Eigen::Vector2d & leftFootPlace,
-    const Eigen::Vector2d & rightFootPlace,
-    const Eigen::Vector2d & CoM,
-    const Eigen::Vector2d & CoM_acc, eVector3 & n);
+  void getNonLinearPart(const eVector6& leftFootWrench,
+                        const eVector6& rightFootWrench,
+                        const Eigen::Vector2d& leftFootPlace,
+                        const Eigen::Vector2d& rightFootPlace,
+                        const Eigen::Vector2d& CoM,
+                        const Eigen::Vector2d& CoM_acc, eVector3& n);
 
-  void getNonLinearPart(
-    const eVector6 & leftFootWrench,
-    const eVector6 & rightFootWrench,
-    const Eigen::Vector2d & leftFootPlace_c,
-    const Eigen::Vector2d & rightFootPlace_c,
-    const Eigen::Vector2d & CoM_acc, eVector3 & n);
+  void getNonLinearPart(const eVector6& leftFootWrench,
+                        const eVector6& rightFootWrench,
+                        const Eigen::Vector2d& leftFootPlace_c,
+                        const Eigen::Vector2d& rightFootPlace_c,
+                        const Eigen::Vector2d& CoM_acc, eVector3& n);
 
-  void getNonLinearPart(
-    const eVector3 & com, const eVector3 & com_acc,
-    const eVector2 & cop, eVector3 & n);
+  void getNonLinearPart(const eVector3& com, const eVector3& com_acc,
+                        const eVector2& cop, eVector3& n);
 
-  void getNonLinearPart(eVector3 & n);
+  void getNonLinearPart(eVector3& n);
 
-  double estimateCopDisturbance(
-    const eVector2 & currentTrackingError,
-    eVector2 & oldTrackingError,
-    const eVector2 & c_gainK);
+  double estimateCopDisturbance(const eVector2& currentTrackingError,
+                                eVector2& oldTrackingError,
+                                const eVector2& c_gainK);
 
-  double estimateJerkDisturbance(
-    const eVector3 & currentTrackingError,
-    eVector3 & oldTrackingError,
-    const eVector3 & c_gainK);
+  double estimateJerkDisturbance(const eVector3& currentTrackingError,
+                                 eVector3& oldTrackingError,
+                                 const eVector3& c_gainK);
 
   bool configured_, first_iter_;
   eMatrixRot A_, Aj_;
@@ -400,9 +397,9 @@ private:
   // Input settings.
   CopStabilizerSettings settings_;
 
-protected:
+ protected:
   Eigen::Vector3d target_com_, target_com_vel_, target_com_acc_,
-    target_com_jerk_, non_linear_;
+      target_com_jerk_, non_linear_;
   eVector2 target_cop_, desired_uncampled_cop_;
   eVector2 errorSum_;
   eVector2 cop_clamped;

--- a/include/biped-stabilizer/cop_stabilizer.hpp
+++ b/include/biped-stabilizer/cop_stabilizer.hpp
@@ -15,7 +15,8 @@
 
 #include "biped-stabilizer/third_party/wykobi/wykobi.hpp"
 
-namespace biped_stabilizer {
+namespace biped_stabilizer
+{
 
 typedef wykobi::polygon<double, 2> Polygon2D;
 typedef Eigen::Matrix<double, 2, 1> eVector2;
@@ -24,7 +25,7 @@ typedef Eigen::Matrix<double, 6, 1> eVector6;
 typedef Eigen::Isometry3d eMatrixHom;
 typedef Eigen::Matrix3d eMatrixRot;
 typedef std::vector<eMatrixHom, Eigen::aligned_allocator<eMatrixHom>>
-    eMatrixHoms;
+  eMatrixHoms;
 typedef std::vector<eVector2, Eigen::aligned_allocator<eVector2>> eVector2s;
 typedef std::vector<eVector3, Eigen::aligned_allocator<eVector3>> eVector3s;
 
@@ -48,7 +49,8 @@ public:
   bool saturate_cop = true;
   bool use_rate_limited_dcm = false;
 
-  bool operator==(const CopStabilizerSettings &rhs) {
+  bool operator==(const CopStabilizerSettings & rhs)
+  {
     bool test = true;
     test &= this->height == rhs.height;
     test &= this->foot_length == rhs.foot_length;
@@ -65,9 +67,10 @@ public:
     return test;
   }
 
-  bool operator!=(const CopStabilizerSettings &rhs) { return !(*this == rhs); }
+  bool operator!=(const CopStabilizerSettings & rhs) {return !(*this == rhs);}
 
-  std::string to_string() {
+  std::string to_string()
+  {
     std::ostringstream oss;
     oss << "CopStabilizerSettings:" << std::endl;
     oss << "    - height = " << this->height << std::endl;
@@ -88,7 +91,8 @@ public:
     return oss.str();
   }
 
-  std::ostream &operator<<(std::ostream &out) {
+  std::ostream & operator<<(std::ostream & out)
+  {
     out << this->to_string();
     return out;
   }
@@ -101,19 +105,16 @@ public:
   CopStabilizer();
 
   /**
-   * @brief CopStabilizer
-   * @param g the gravity constant along z
-   * @param height the default height of the CoM
-   * @param dt the timestep used by the controller
-   * @param cop_gains the gains (x, y, z) used by the feedback law
+   * @brief CopStabilizer stabilize the CoP around a reference point.
+   * @param settings the settings for the CoP stabilizer, see CopStabilizerSettings.
    */
-  CopStabilizer(const CopStabilizerSettings &settings);
+  CopStabilizer(const CopStabilizerSettings & settings);
 
   virtual ~CopStabilizer();
 
-  void configure(const CopStabilizerSettings &settings);
+  void configure(const CopStabilizerSettings & settings);
 
-  const CopStabilizerSettings &getSettings() { return settings_; }
+  const CopStabilizerSettings & getSettings() {return settings_;}
 
   void stabilize(const eVector3 &actual_com, const eVector3 &actual_com_vel,
                  const eVector3 &actual_com_acc, const eVector3 &actual_cop,
@@ -189,29 +190,110 @@ public:
                      eVector3 &actual_icp,            // ???
                      eVector3 &desired_cop_reference, // ???
                      eVector3 &desired_cop_computed);
+  void stabilize(
+    const eVector3 & actual_com, const eVector3 & actual_com_vel,
+    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
+    const eMatrixHoms & actual_stance_poses,
+    const eVector3 & reference_com,
+    const eVector3 & reference_com_vel,
+    const eVector3 & reference_com_acc,
+    const eVector3 & reference_com_jerk, eVector3 & desired_com,
+    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
+    eVector3 & desired_icp,                        // ???
+    eVector3 & actual_icp,                         // ???
+    eVector2 & desired_cop_reference,              // ???
+    eVector2 & desired_cop_computed);
 
-  double distributeForces(const eVector2 &desired_cop, const eVector2 LF_xy,
-                          const double LF_force_z, const eVector2 LF_torque_xy,
-                          const eVector2 RF_xy, const double RF_force_z,
-                          const eVector2 RF_torque_xy);
+  void stabilize(
+    const eVector3 & actual_com, const eVector3 & actual_com_vel,
+    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
+    const Polygon2D & support_polygon,
+    const eVector3 & reference_com,
+    const eVector3 & reference_com_vel,
+    const eVector3 & reference_com_acc,
+    const eVector3 & reference_com_jerk, eVector3 & desired_com,
+    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
+    eVector3 & desired_icp,                        // ???
+    eVector3 & actual_icp,                         // ???
+    eVector2 & desired_cop_reference,              // ???
+    eVector2 & desired_cop_computed);
 
-  std::array<eVector3, 3> getStableCoMs(const double &com_height);
+  void stabilizeCOP(
+    const eVector3 & actual_com, const eVector3 & actual_com_vel,
+    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
+    const Polygon2D & support_polygon,
+    const eVector3 & reference_com,
+    const eVector3 & reference_com_vel,
+    const eVector3 & reference_com_acc, eVector3 & desired_com,
+    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
+    eVector3 & desired_icp,                           // ???
+    eVector3 & actual_icp,                            // ???
+    eVector2 & desired_cop_reference,                 // ???
+    eVector2 & desired_cop_computed);
 
-  void setCOPgains(const eVector3 &cop_x_gains, eVector3 &cop_y_gains);
+  void stabilizeApproximateAcceleration(
+    const eVector3 & actual_com, const eVector3 & actual_com_vel,
+    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
+    const Polygon2D & support_polygon, const eVector3 & reference_com,
+    const eVector3 & reference_com_vel, const eVector3 & reference_com_acc,
+    eVector3 & desired_com, eVector3 & desired_com_vel,
+    eVector3 & desired_com_acc,
+    eVector3 & desired_icp,             // ???
+    eVector3 & actual_icp,              // ???
+    eVector2 & desired_cop_reference,   // ???
+    eVector2 & desired_cop_computed);
+
+  void stabilizeP_CC(
+    const eVector3 & actual_com, const eVector3 & actual_com_vel,
+    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
+    const Polygon2D & support_polygon,
+    const eVector3 & reference_com,
+    const eVector3 & reference_com_vel,
+    const eVector3 & reference_com_acc, eVector3 & desired_com,
+    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
+    eVector3 & desired_icp,                            // ???
+    eVector3 & actual_icp,                             // ???
+    eVector2 & desired_cop_reference,                  // ???
+    eVector2 & desired_cop_computed);
+
+  void stabilizeJerk(
+    const eVector3 & actual_com, const eVector3 & actual_com_vel,
+    const eVector3 & actual_com_acc, const eVector2 & actual_cop,
+    const Polygon2D & support_polygon,
+    const eVector3 & reference_com,
+    const eVector3 & reference_com_vel,
+    const eVector3 & reference_com_acc,
+    const eVector3 & reference_com_jerk, eVector3 & desired_com,
+    eVector3 & desired_com_vel, eVector3 & desired_com_acc,
+    eVector3 & desired_icp,                            // ???
+    eVector3 & actual_icp,                             // ???
+    eVector2 & desired_cop_reference,                  // ???
+    eVector2 & desired_cop_computed);
+
+  double distributeForces(
+    const eVector2 & desired_cop, const eVector2 LF_xy,
+    const double LF_force_z, const eVector2 LF_torque_xy,
+    const eVector2 RF_xy, const double RF_force_z,
+    const eVector2 RF_torque_xy);
+
+  std::array<eVector3, 3> getStableCoMs(const double & com_height);
+
+  void setCOPgains(const eVector3 & cop_x_gains, const eVector3 & cop_y_gains);
 
   void setPCCgains(const double cop_pcc_gains);
 
-  void setIntegralGains(const eVector2 &integral_gains);
+  void setIntegralGains(const eVector2 & integral_gains);
 
 private:
   void computeSupportPolygon(const eMatrixHoms &stance_poses,
                              Polygon2D &convex_hull);
 
-  void projectCOPinSupportPolygon(const eVector2 &target_cop_unclamped,
-                                  const Polygon2D &polygon,
-                                  eVector2 &target_cop);
+  void projectCOPinSupportPolygon(
+    const eVector2 & target_cop_unclamped,
+    const Polygon2D & polygon,
+    eVector2 & target_cop);
 
-  bool isPointInPolygon(const eVector2 &point, const Polygon2D &polygon);
+  bool isPointInPolygon(const eVector2 & point, const Polygon2D & polygon);
 
   /**
    * @brief getActualCOM_acc compute COM acceleration from the contact forces
@@ -221,7 +303,7 @@ private:
    * gravity and ground contact forces.
    * @return the COM acceleration
    */
-  Eigen::Vector3d getActualCOM_acc(const Eigen::Vector3d &externalForce);
+  Eigen::Vector3d getActualCOM_acc(const Eigen::Vector3d & externalForce);
 
   /**
    * @brief movingAverage Insert x at the beginning of the queue, remove all the
@@ -232,42 +314,48 @@ private:
    * @param MA_queue
    * @return
    */
-  template <typename T, typename vec_T>
-  T movingAverage(const T x, const unsigned long nb_samples, vec_T &queue);
+  template<typename T, typename vec_T>
+  T movingAverage(const T x, const unsigned long nb_samples, vec_T & queue);
 
-  void getNonLinearPart(const eVector6 &leftFootWrench,
-                        const eVector6 &rightFootWrench,
-                        const Eigen::Vector2d &leftFootPlace,
-                        const Eigen::Vector2d &rightFootPlace,
-                        const Eigen::Vector2d &CoM,
-                        const Eigen::Vector2d &lateral_gravity,
-                        const Eigen::Vector2d &externalForce, eVector3 &n);
+  void getNonLinearPart(
+    const eVector6 & leftFootWrench,
+    const eVector6 & rightFootWrench,
+    const Eigen::Vector2d & leftFootPlace,
+    const Eigen::Vector2d & rightFootPlace,
+    const Eigen::Vector2d & CoM,
+    const Eigen::Vector2d & lateral_gravity,
+    const Eigen::Vector2d & externalForce, eVector3 & n);
 
-  void getNonLinearPart(const eVector6 &leftFootWrench,
-                        const eVector6 &rightFootWrench,
-                        const Eigen::Vector2d &leftFootPlace,
-                        const Eigen::Vector2d &rightFootPlace,
-                        const Eigen::Vector2d &CoM,
-                        const Eigen::Vector2d &CoM_acc, eVector3 &n);
+  void getNonLinearPart(
+    const eVector6 & leftFootWrench,
+    const eVector6 & rightFootWrench,
+    const Eigen::Vector2d & leftFootPlace,
+    const Eigen::Vector2d & rightFootPlace,
+    const Eigen::Vector2d & CoM,
+    const Eigen::Vector2d & CoM_acc, eVector3 & n);
 
-  void getNonLinearPart(const eVector6 &leftFootWrench,
-                        const eVector6 &rightFootWrench,
-                        const Eigen::Vector2d &leftFootPlace_c,
-                        const Eigen::Vector2d &rightFootPlace_c,
-                        const Eigen::Vector2d &CoM_acc, eVector3 &n);
+  void getNonLinearPart(
+    const eVector6 & leftFootWrench,
+    const eVector6 & rightFootWrench,
+    const Eigen::Vector2d & leftFootPlace_c,
+    const Eigen::Vector2d & rightFootPlace_c,
+    const Eigen::Vector2d & CoM_acc, eVector3 & n);
 
-  void getNonLinearPart(const eVector3 &com, const eVector3 &com_acc,
-                        const eVector3 &cop, eVector3 &n);
+  void getNonLinearPart(
+    const eVector3 & com, const eVector3 & com_acc,
+    const eVector2 & cop, eVector3 & n);
 
-  void getNonLinearPart(eVector3 &n);
+  void getNonLinearPart(eVector3 & n);
 
-  double estimateCopDisturbance(const eVector2 &currentTrackingError,
-                                eVector2 &oldTrackingError,
-                                const eVector2 &c_gainK);
+  double estimateCopDisturbance(
+    const eVector2 & currentTrackingError,
+    eVector2 & oldTrackingError,
+    const eVector2 & c_gainK);
 
-  double estimateJerkDisturbance(const eVector3 &currentTrackingError,
-                                 eVector3 &oldTrackingError,
-                                 const eVector3 &c_gainK);
+  double estimateJerkDisturbance(
+    const eVector3 & currentTrackingError,
+    eVector3 & oldTrackingError,
+    const eVector3 & c_gainK);
 
   bool configured_, first_iter_;
   eMatrixRot A_, Aj_;
@@ -314,7 +402,7 @@ private:
 
 protected:
   Eigen::Vector3d target_com_, target_com_vel_, target_com_acc_,
-      target_com_jerk_, non_linear_;
+    target_com_jerk_, non_linear_;
   eVector2 target_cop_, desired_uncampled_cop_;
   eVector2 errorSum_;
   eVector2 cop_clamped;

--- a/python/biped_stabilizer.cpp
+++ b/python/biped_stabilizer.cpp
@@ -9,6 +9,7 @@
 BOOST_PYTHON_MODULE(biped_stabilizer_cpp) {
   // Enabling eigenpy support, i.e. numpy/eigen compatibility.
   eigenpy::enableEigenPy();
+  ENABLE_SPECIFIC_MATRIX_TYPE(Eigen::Vector2d);
   ENABLE_SPECIFIC_MATRIX_TYPE(Eigen::Vector3d);
   ENABLE_SPECIFIC_MATRIX_TYPE(Eigen::Matrix3d);
   eigenpy::exposeQuaternion();

--- a/python/cop_stabilizer.cpp
+++ b/python/cop_stabilizer.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include "biped-stabilizer/cop_stabilizer.hpp"
+#include <iostream>
 
 #include <boost/python.hpp>
 #include <boost/python/return_internal_reference.hpp>
@@ -27,7 +27,7 @@ bp::tuple CopStabilizer_stabilize(CopStabilizer &self, bp::dict args) {
   eVector3 actual_com = bp::extract<eVector3>(args["actual_com"]);
   eVector3 actual_com_vel = bp::extract<eVector3>(args["actual_com_vel"]);
   eVector3 actual_com_acc = bp::extract<eVector3>(args["actual_com_acc"]);
-  
+
   bool is_2d = false;
   eVector3 actual_cop_3d;
   eVector2 actual_cop_2d;
@@ -44,7 +44,7 @@ bp::tuple CopStabilizer_stabilize(CopStabilizer &self, bp::dict args) {
   } else {
     throw std::runtime_error("actual_cop must be of size 2 or 3");
   }
-  
+
   eVector3 reference_com = bp::extract<eVector3>(args["reference_com"]);
   eVector3 reference_com_vel = bp::extract<eVector3>(args["reference_com_vel"]);
   eVector3 reference_com_acc = bp::extract<eVector3>(args["reference_com_acc"]);
@@ -62,28 +62,25 @@ bp::tuple CopStabilizer_stabilize(CopStabilizer &self, bp::dict args) {
 
   eMatrixHoms actual_stance_poses;
   to_std_vector(args["actual_stance_poses"], actual_stance_poses);
-  if (is_2d)
-  {
+  if (is_2d) {
     self.stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop_2d,
-                 actual_stance_poses, reference_com, reference_com_vel,
-                 reference_com_acc, reference_com_jerk, desired_com,
-                 desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-                 desired_cop_reference_2d, desired_cop_computed_2d);
+                   actual_stance_poses, reference_com, reference_com_vel,
+                   reference_com_acc, reference_com_jerk, desired_com,
+                   desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+                   desired_cop_reference_2d, desired_cop_computed_2d);
     return bp::make_tuple(desired_com, desired_com_vel, desired_com_acc,
                           desired_icp, actual_icp, desired_cop_reference_2d,
                           desired_cop_computed_2d);
   } else {
     self.stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop_3d,
-                 actual_stance_poses, reference_com, reference_com_vel,
-                 reference_com_acc, reference_com_jerk, desired_com,
-                 desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-                 desired_cop_reference_3d, desired_cop_computed_3d);
+                   actual_stance_poses, reference_com, reference_com_vel,
+                   reference_com_acc, reference_com_jerk, desired_com,
+                   desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+                   desired_cop_reference_3d, desired_cop_computed_3d);
     return bp::make_tuple(desired_com, desired_com_vel, desired_com_acc,
                           desired_icp, actual_icp, desired_cop_reference_3d,
                           desired_cop_computed_3d);
   }
-  
-  
 }
 
 void exposeCopStabilizer() {

--- a/python/cop_stabilizer.cpp
+++ b/python/cop_stabilizer.cpp
@@ -1,4 +1,4 @@
-
+#include <iostream>
 #include "biped-stabilizer/cop_stabilizer.hpp"
 
 #include <boost/python.hpp>
@@ -27,7 +27,24 @@ bp::tuple CopStabilizer_stabilize(CopStabilizer &self, bp::dict args) {
   eVector3 actual_com = bp::extract<eVector3>(args["actual_com"]);
   eVector3 actual_com_vel = bp::extract<eVector3>(args["actual_com_vel"]);
   eVector3 actual_com_acc = bp::extract<eVector3>(args["actual_com_acc"]);
-  eVector3 actual_cop = bp::extract<eVector3>(args["actual_cop"]);
+  
+  bool is_2d = false;
+  eVector3 actual_cop_3d;
+  eVector2 actual_cop_2d;
+  bp::object shape_obj = args["actual_cop"].attr("shape");
+  int size_of_cop = bp::extract<int>(shape_obj[0]);
+  if (size_of_cop == 2) {
+    // Try to extract as eVector2
+    actual_cop_2d = bp::extract<eVector2>(args["actual_cop"]);
+    is_2d = true;
+  } else if (size_of_cop == 3) {
+    // Try to extract as eVector3
+    actual_cop_3d = bp::extract<eVector3>(args["actual_cop"]);
+    is_2d = false;
+  } else {
+    throw std::runtime_error("actual_cop must be of size 2 or 3");
+  }
+  
   eVector3 reference_com = bp::extract<eVector3>(args["reference_com"]);
   eVector3 reference_com_vel = bp::extract<eVector3>(args["reference_com_vel"]);
   eVector3 reference_com_acc = bp::extract<eVector3>(args["reference_com_acc"]);
@@ -38,19 +55,35 @@ bp::tuple CopStabilizer_stabilize(CopStabilizer &self, bp::dict args) {
   eVector3 desired_com_acc;
   eVector3 desired_icp;
   eVector3 actual_icp;
-  eVector3 desired_cop_reference;
-  eVector3 desired_cop_computed;
+  eVector3 desired_cop_reference_3d;
+  eVector3 desired_cop_computed_3d;
+  eVector2 desired_cop_reference_2d;
+  eVector2 desired_cop_computed_2d;
 
   eMatrixHoms actual_stance_poses;
   to_std_vector(args["actual_stance_poses"], actual_stance_poses);
-  self.stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop,
+  if (is_2d)
+  {
+    self.stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop_2d,
                  actual_stance_poses, reference_com, reference_com_vel,
                  reference_com_acc, reference_com_jerk, desired_com,
                  desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-                 desired_cop_reference, desired_cop_computed);
-  return bp::make_tuple(desired_com, desired_com_vel, desired_com_acc,
-                        desired_icp, actual_icp, desired_cop_reference,
-                        desired_cop_computed);
+                 desired_cop_reference_2d, desired_cop_computed_2d);
+    return bp::make_tuple(desired_com, desired_com_vel, desired_com_acc,
+                          desired_icp, actual_icp, desired_cop_reference_2d,
+                          desired_cop_computed_2d);
+  } else {
+    self.stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop_3d,
+                 actual_stance_poses, reference_com, reference_com_vel,
+                 reference_com_acc, reference_com_jerk, desired_com,
+                 desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+                 desired_cop_reference_3d, desired_cop_computed_3d);
+    return bp::make_tuple(desired_com, desired_com_vel, desired_com_acc,
+                          desired_icp, actual_icp, desired_cop_reference_3d,
+                          desired_cop_computed_3d);
+  }
+  
+  
 }
 
 void exposeCopStabilizer() {

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -1,6 +1,6 @@
-#include <iostream>
 #include "biped-stabilizer/cop_stabilizer.hpp"
 #include "biped-stabilizer/third_party/wykobi/wykobi_algorithm.hpp"
+#include <iostream>
 
 namespace biped_stabilizer {
 
@@ -148,8 +148,10 @@ void CopStabilizer::stabilize(
   desired_cop_reference.z() = 0.0;
   desired_cop_computed.head<2>() = desired_cop_reference_2d;
   desired_cop_computed.z() = 0.0;
-  std::cout << "desired_cop_reference: " << desired_cop_reference.transpose() << std::endl;
-  std::cout << "desired_cop_computed: " << desired_cop_computed.transpose() << std::endl;
+  std::cout << "desired_cop_reference: " << desired_cop_reference.transpose()
+            << std::endl;
+  std::cout << "desired_cop_computed: " << desired_cop_computed.transpose()
+            << std::endl;
 }
 
 void CopStabilizer::stabilize(
@@ -169,9 +171,9 @@ void CopStabilizer::stabilize(
   } // else skip computation to save computation time
   stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop,
             support_polygon, reference_com, reference_com_vel,
-            reference_com_acc, reference_com_jerk, desired_com,
-            desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-            desired_cop_reference, desired_cop_computed);
+            reference_com_acc, reference_com_jerk, desired_com, desired_com_vel,
+            desired_com_acc, desired_icp, actual_icp, desired_cop_reference,
+            desired_cop_computed);
 }
 
 void CopStabilizer::stabilize(
@@ -362,19 +364,15 @@ void CopStabilizer::stabilizeCOP( // Not supported
   }
 
   desired_com = eVector3(nextState_x(0), nextState_y(0), reference_com.z());
-  desired_com_vel = eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
-  desired_com_acc = eVector3(
-    w2_ * (nextState_x(0) - nextState_x(2)),
-    w2_ * (nextState_y(0) - nextState_y(2)),
-    reference_com_acc.z());
-  desired_icp = eVector3(
-    nextState_x(0) + nextState_x(1) / w_,
-    nextState_y(0) + nextState_y(1) / w_,
-    0.);
-  actual_icp = eVector3(
-    actualState_x(0) + actualState_x(1) / w_,
-    actualState_y(0) + actualState_y(1) / w_,
-    0.);
+  desired_com_vel =
+      eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
+  desired_com_acc =
+      eVector3(w2_ * (nextState_x(0) - nextState_x(2)),
+               w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z());
+  desired_icp = eVector3(nextState_x(0) + nextState_x(1) / w_,
+                         nextState_y(0) + nextState_y(1) / w_, 0.);
+  actual_icp = eVector3(actualState_x(0) + actualState_x(1) / w_,
+                        actualState_y(0) + actualState_y(1) / w_, 0.);
   desired_cop_reference = eVector2(referenceState_x(2), referenceState_y(2));
   desired_cop_computed = eVector2(nextState_x(2), nextState_y(2));
 
@@ -503,19 +501,15 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   }
 
   desired_com = eVector3(nextState_x(0), nextState_y(0), reference_com.z());
-  desired_com_vel = eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
-  desired_com_acc = eVector3(
-    w2_ * (nextState_x(0) - nextState_x(2)),
-    w2_ * (nextState_y(0) - nextState_y(2)),
-    reference_com_acc.z());
-  desired_icp = eVector3(
-    nextState_x(0) + nextState_x(1) / w_,
-    nextState_y(0) + nextState_y(1) / w_,
-    0.);
-  actual_icp = eVector3(
-    actualState_x(0) + actualState_x(1) / w_,
-    actualState_y(0) + actualState_y(1) / w_,
-    0.);
+  desired_com_vel =
+      eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
+  desired_com_acc =
+      eVector3(w2_ * (nextState_x(0) - nextState_x(2)),
+               w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z());
+  desired_icp = eVector3(nextState_x(0) + nextState_x(1) / w_,
+                         nextState_y(0) + nextState_y(1) / w_, 0.);
+  actual_icp = eVector3(actualState_x(0) + actualState_x(1) / w_,
+                        actualState_y(0) + actualState_y(1) / w_, 0.);
   desired_cop_reference = eVector2(referenceState_x(2), referenceState_y(2));
   desired_cop_computed = eVector2(nextState_x(2), nextState_y(2));
 
@@ -634,19 +628,15 @@ void CopStabilizer::stabilizeP_CC(
   nextState_y = A22_ * actualState2d_y_ + B2_ * actual_command_.y();
 
   desired_com = eVector3(nextState_x(0), nextState_y(0), reference_com.z());
-  desired_com_vel = eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
-  desired_com_acc = eVector3(
-    w2_ * (nextState_x(0) - actual_command_.x()),
-    w2_ * (nextState_y(0) - actual_command_.y()),
-    reference_com_acc.z());
-  desired_icp = eVector3(
-    nextState_x(0) + nextState_x(1) / w_,
-    nextState_y(0) + nextState_y(1) / w_,
-    0.);
-  actual_icp = eVector3(
-    actualState2d_x_(0) + actualState2d_x_(1) / w_,
-    actualState2d_y_(0) + actualState2d_y_(1) / w_,
-    0.);
+  desired_com_vel =
+      eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
+  desired_com_acc = eVector3(w2_ * (nextState_x(0) - actual_command_.x()),
+                             w2_ * (nextState_y(0) - actual_command_.y()),
+                             reference_com_acc.z());
+  desired_icp = eVector3(nextState_x(0) + nextState_x(1) / w_,
+                         nextState_y(0) + nextState_y(1) / w_, 0.);
+  actual_icp = eVector3(actualState2d_x_(0) + actualState2d_x_(1) / w_,
+                        actualState2d_y_(0) + actualState2d_y_(1) / w_, 0.);
   desired_cop_reference = referenceCCOP + non_linear_.head<2>();
   desired_cop_computed = actual_command_ + non_linear_.head<2>();
 }
@@ -756,7 +746,7 @@ void CopStabilizer::stabilizeJerk(
                                     Bj_ * reference_com_jerk.y());
       const eVector2 nextRefCCOP(nextRefState_x(0) - nextRefState_x(2) / w2_,
                                  nextRefState_y(0) - nextRefState_y(2) / w2_);
-      eVector3 L (1, 0, -1 / w2_);
+      eVector3 L(1, 0, -1 / w2_);
 
       const eVector2 LA_trErr_0(L.transpose() * Aj_ * stateTrackingError_x,
                                 L.transpose() * Aj_ * stateTrackingError_y);
@@ -772,22 +762,19 @@ void CopStabilizer::stabilizeJerk(
   }
 
   desired_com = eVector3(nextState_x(0), nextState_y(0), reference_com.z());
-  desired_com_vel = eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
-  desired_com_acc = eVector3(nextState_x(2), nextState_y(2), reference_com_acc.z());
-  desired_icp = eVector3(
-    nextState_x(0) + nextState_x(1) / w_,
-    nextState_y(0) + nextState_y(1) / w_,
-    0.);
-  actual_icp = eVector3(
-    actualState3d_x_(0) + actualState3d_x_(1) / w_,
-    actualState3d_y_(0) + actualState3d_y_(1) / w_,
-    0.);
-  desired_cop_reference = eVector2(
-    referenceCCOP.x() + non_linear_.x(),
-    referenceCCOP.y() + non_linear_.y());
-  desired_cop_computed = eVector2(
-    nextState_x(0) - nextState_x(2) / w2_ + non_linear_.x(),
-    nextState_y(0) - nextState_y(2) / w2_ + non_linear_.y());
+  desired_com_vel =
+      eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
+  desired_com_acc =
+      eVector3(nextState_x(2), nextState_y(2), reference_com_acc.z());
+  desired_icp = eVector3(nextState_x(0) + nextState_x(1) / w_,
+                         nextState_y(0) + nextState_y(1) / w_, 0.);
+  actual_icp = eVector3(actualState3d_x_(0) + actualState3d_x_(1) / w_,
+                        actualState3d_y_(0) + actualState3d_y_(1) / w_, 0.);
+  desired_cop_reference = eVector2(referenceCCOP.x() + non_linear_.x(),
+                                   referenceCCOP.y() + non_linear_.y());
+  desired_cop_computed =
+      eVector2(nextState_x(0) - nextState_x(2) / w2_ + non_linear_.x(),
+               nextState_y(0) - nextState_y(2) / w2_ + non_linear_.y());
 }
 
 double CopStabilizer::distributeForces(

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -1,5 +1,5 @@
+#include <iostream>
 #include "biped-stabilizer/cop_stabilizer.hpp"
-
 #include "biped-stabilizer/third_party/wykobi/wykobi_algorithm.hpp"
 
 namespace biped_stabilizer {
@@ -148,6 +148,8 @@ void CopStabilizer::stabilize(
   desired_cop_reference.z() = 0.0;
   desired_cop_computed.head<2>() = desired_cop_reference_2d;
   desired_cop_computed.z() = 0.0;
+  std::cout << "desired_cop_reference: " << desired_cop_reference.transpose() << std::endl;
+  std::cout << "desired_cop_computed: " << desired_cop_computed.transpose() << std::endl;
 }
 
 void CopStabilizer::stabilize(

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -2,8 +2,7 @@
 
 #include "biped-stabilizer/third_party/wykobi/wykobi_algorithm.hpp"
 
-namespace biped_stabilizer
-{
+namespace biped_stabilizer {
 
 const double DT_DERIVATIVE = 1e-4;
 
@@ -19,10 +18,9 @@ CopStabilizer::CopStabilizer(const CopStabilizerSettings &settings)
 
 CopStabilizer::~CopStabilizer() {}
 
-void CopStabilizer::configure(const CopStabilizerSettings & settings)
-{
+void CopStabilizer::configure(const CopStabilizerSettings& settings) {
   settings_ = settings;
-  const double & dt = settings_.dt;
+  const double& dt = settings_.dt;
   configured_ = true;
   first_iter_ = true;
   w2_ = settings_.g / settings_.height;
@@ -31,7 +29,7 @@ void CopStabilizer::configure(const CopStabilizerSettings & settings)
   // These system matrices correspond to "dP->CCP" state: c, c_dot, ccop and
   // input ccop_dot
   A_ << cosh(w_ * dt), sinh(w_ * dt) / w_, 1 - cosh(w_ * dt),
-    w_ * sinh(w_ * dt), cosh(w_ * dt), -w_ * sinh(w_ * dt), 0, 0, 1;
+      w_ * sinh(w_ * dt), cosh(w_ * dt), -w_ * sinh(w_ * dt), 0, 0, 1;
   B_ << dt - sinh(w_ * dt) / w_, 1 - cosh(w_ * dt), dt;
 
   cx_gainK_ = settings_.cop_x_gains;
@@ -50,16 +48,16 @@ void CopStabilizer::configure(const CopStabilizerSettings & settings)
 
   // values for J_CCC method
   S_coms_j_ << 1, dt - DT_DERIVATIVE, pow(dt - DT_DERIVATIVE, 2) / 2, 1, dt,
-    pow(dt, 2) / 2, 1, dt + DT_DERIVATIVE, pow(dt + DT_DERIVATIVE, 2) / 2;
+      pow(dt, 2) / 2, 1, dt + DT_DERIVATIVE, pow(dt + DT_DERIVATIVE, 2) / 2;
   U_coms_j_ << pow(dt - DT_DERIVATIVE, 3) / 6, pow(dt, 3) / 6,
-    pow(dt + DT_DERIVATIVE, 3) / 6;
+      pow(dt + DT_DERIVATIVE, 3) / 6;
 
   // Values for P_CC method
   S_coms_ << cosh(w_ * (dt - DT_DERIVATIVE)),
-    sinh(w_ * (dt - DT_DERIVATIVE)) / w_, cosh(w_ * dt), sinh(w_ * dt) / w_,
-    cosh(w_ * (dt + DT_DERIVATIVE)), sinh(w_ * (dt + DT_DERIVATIVE)) / w_;
+      sinh(w_ * (dt - DT_DERIVATIVE)) / w_, cosh(w_ * dt), sinh(w_ * dt) / w_,
+      cosh(w_ * (dt + DT_DERIVATIVE)), sinh(w_ * (dt + DT_DERIVATIVE)) / w_;
   U_coms_ << 1 - cosh(w_ * (dt - DT_DERIVATIVE)), 1 - cosh(w_ * dt),
-    1 - cosh(w_ * (dt + DT_DERIVATIVE));
+      1 - cosh(w_ * (dt + DT_DERIVATIVE));
 
   target_com_.setZero();
   target_com_vel_.setZero();
@@ -76,13 +74,13 @@ void CopStabilizer::configure(const CopStabilizerSettings & settings)
 
   local_foot_description_.resize(4);
   local_foot_description_[0] =
-    eVector3(settings_.foot_length / 2, settings_.foot_width / 2, 0.);
+      eVector3(settings_.foot_length / 2, settings_.foot_width / 2, 0.);
   local_foot_description_[1] =
-    eVector3(settings_.foot_length / 2, -settings_.foot_width / 2, 0.);
+      eVector3(settings_.foot_length / 2, -settings_.foot_width / 2, 0.);
   local_foot_description_[2] =
-    eVector3(-settings_.foot_length / 2, settings_.foot_width / 2, 0.);
+      eVector3(-settings_.foot_length / 2, settings_.foot_width / 2, 0.);
   local_foot_description_[3] =
-    eVector3(-settings_.foot_length / 2, -settings_.foot_width / 2, 0.);
+      eVector3(-settings_.foot_length / 2, -settings_.foot_width / 2, 0.);
   foot_description_.clear();
   foot_description_.reserve(10 * 4);
   wykobi_foot_description_.clear();
@@ -130,10 +128,8 @@ void CopStabilizer::configure(const CopStabilizerSettings & settings)
   //                   &errorSum_[1], &registered_variables_);
 }
 
-void CopStabilizer::computeSupportPolygon(
-  const eMatrixHoms & stance_poses,
-  Polygon2D & convex_hull)
-{
+void CopStabilizer::computeSupportPolygon(const eMatrixHoms& stance_poses,
+                                          Polygon2D& convex_hull) {
   // Compute the global position of the feet edges.
   foot_description_.clear();
   for (size_t j = 0; j < stance_poses.size(); j++) {
@@ -145,19 +141,18 @@ void CopStabilizer::computeSupportPolygon(
   wykobi_foot_description_.clear();
   for (size_t i = 0; i < foot_description_.size(); ++i) {
     wykobi_foot_description_.push_back(
-      wykobi::make_point(foot_description_[i](0), foot_description_[i](1)));
+        wykobi::make_point(foot_description_[i](0), foot_description_[i](1)));
   }
   // Compute the convex hull.
   convex_hull.clear();
   wykobi::algorithm::convex_hull_graham_scan<wykobi::point2d<double>>(
-    wykobi_foot_description_.begin(), wykobi_foot_description_.end(),
-    std::back_inserter(convex_hull));
+      wykobi_foot_description_.begin(), wykobi_foot_description_.end(),
+      std::back_inserter(convex_hull));
 }
 
 void CopStabilizer::projectCOPinSupportPolygon(
-  const eVector2 & target_cop_unclamped, const Polygon2D & polygon,
-  eVector2 & target_cop)
-{
+    const eVector2& target_cop_unclamped, const Polygon2D& polygon,
+    eVector2& target_cop) {
   wykobi_cop_unclamped_.x = target_cop_unclamped.x();
   wykobi_cop_unclamped_.y = target_cop_unclamped.y();
   if (wykobi::point_in_convex_polygon(wykobi_cop_unclamped_, polygon)) {
@@ -166,7 +161,7 @@ void CopStabilizer::projectCOPinSupportPolygon(
     // ROS_INFO("[com_control_utils] COP_unclamped not in the support polygon
     // !");
     wykobi_cop_clamped_ = wykobi::closest_point_on_polygon_from_point(
-      polygon, wykobi_cop_unclamped_);
+        polygon, wykobi_cop_unclamped_);
     target_cop.x() = wykobi_cop_clamped_.x;
     target_cop.y() = wykobi_cop_clamped_.y;
   }
@@ -219,20 +214,19 @@ void CopStabilizer::stabilize(
                          desired_cop_reference, desired_cop_computed);
   else if (settings_.cop_control_type == "approximated_acceleration")
     return stabilizeApproximateAcceleration(
-      actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
-      reference_com, reference_com_vel, reference_com_acc, desired_com,
-      desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-      desired_cop_reference, desired_cop_computed);
+        actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
+        reference_com, reference_com_vel, reference_com_acc, desired_com,
+        desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+        desired_cop_reference, desired_cop_computed);
   } else if (settings_.cop_control_type == "j_ccc") {
     return stabilizeJerk(
-      actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
-      reference_com, reference_com_vel, reference_com_acc, reference_com_jerk,
-      desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-      desired_cop_reference, desired_cop_computed);
+        actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
+        reference_com, reference_com_vel, reference_com_acc, reference_com_jerk,
+        desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+        desired_cop_reference, desired_cop_computed);
   } else {
-    throw std::runtime_error(
-            "Invalid cop control type, got : " +
-            settings_.cop_control_type);
+    throw std::runtime_error("Invalid cop control type, got : " +
+                             settings_.cop_control_type);
   }
 }
 
@@ -249,10 +243,10 @@ void CopStabilizer::stabilizeCOP( // Not supported
   // ROS_INFO("Call stabilizeCOP");
   if (!configured_) {
     throw std::runtime_error(
-            "Stabilizer not initialized, please call the constructor with "
-            "arguments first");
+        "Stabilizer not initialized, please call the constructor with "
+        "arguments first");
   }
-  const double & dt = settings_.dt;
+  const double& dt = settings_.dt;
 
   target_com_ = reference_com;
   target_com_vel_ = reference_com_vel;
@@ -260,31 +254,31 @@ void CopStabilizer::stabilizeCOP( // Not supported
 
   // REAL values
   const Eigen::Vector3d actualState_x(actual_com.x(), actual_com_vel.x(),
-    actual_cop.x());
+                                      actual_cop.x());
   const Eigen::Vector3d actualState_y(actual_com.y(), actual_com_vel.y(),
-    actual_cop.y());
+                                      actual_cop.y());
 
   // Reference values
   const Eigen::Vector3d reference_com_jerky(
-    (reference_com_acc - old_reference_com_acc_) / dt);
+      (reference_com_acc - old_reference_com_acc_) / dt);
   const Eigen::Vector3d reference_com_jerk(
-    movingAverage(reference_com_jerky, 5, jerk_ma_queue_));
+      movingAverage(reference_com_jerky, 5, jerk_ma_queue_));
   const Eigen::Vector2d referenceCCOP(reference_com.head<2>() -
-    reference_com_acc.head<2>() / w2_);
+                                      reference_com_acc.head<2>() / w2_);
   const Eigen::Vector2d referenceCCOP_vel(reference_com_vel.head<2>() -
-    reference_com_jerk.head<2>() / w2_);
+                                          reference_com_jerk.head<2>() / w2_);
 
   const Eigen::Vector3d referenceState_x(
-    reference_com.x(), reference_com_vel.x(), referenceCCOP.x());
+      reference_com.x(), reference_com_vel.x(), referenceCCOP.x());
   const Eigen::Vector3d referenceState_y(
-    reference_com.y(), reference_com_vel.y(), referenceCCOP.y());
+      reference_com.y(), reference_com_vel.y(), referenceCCOP.y());
 
   // Tracking
   Eigen::Vector3d stateTrackingError_x(actualState_x - referenceState_x);
   Eigen::Vector3d stateTrackingError_y(actualState_y - referenceState_y);
   Eigen::Vector2d feedbackTerm;
   feedbackTerm << cx_gainK_.transpose() * stateTrackingError_x,
-    cy_gainK_.transpose() * stateTrackingError_y;
+      cy_gainK_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM
@@ -300,34 +294,34 @@ void CopStabilizer::stabilizeCOP( // Not supported
   getNonLinearPart(actual_com, actual_com_acc, actual_cop, non_linear_);
   if (settings_.saturate_cop) {
     Eigen::Vector2d COP_unclamped(nextState_x(2) + non_linear_(0),
-      nextState_y(2) + non_linear_(1));
+                                  nextState_y(2) + non_linear_(1));
 
     if (!isPointInPolygon(COP_unclamped, support_polygon)) {
       eVector2 COP_clamped;
       projectCOPinSupportPolygon(COP_unclamped, support_polygon, COP_clamped);
 
       eVector3 nextRefState_x(A_ * referenceState_x +
-        B_ * referenceCCOP_vel.x());
+                              B_ * referenceCCOP_vel.x());
       eVector3 nextRefState_y(A_ * referenceState_y +
-        B_ * referenceCCOP_vel.y());
+                              B_ * referenceCCOP_vel.y());
       eVector2 nextRefCCOP(nextRefState_x(2), nextRefState_y(2));
       eVector2 LA_trErr_0(A_.block<1, 3>(2, 0) * stateTrackingError_x,
-        A_.block<1, 3>(2, 0) * stateTrackingError_y);
+                          A_.block<1, 3>(2, 0) * stateTrackingError_y);
 
       eVector2 r =
-        COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0;
+          COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0;
 
       eVector3 stateTrackingError_clamped_x =
-        cx_gainK_ * r.x() / (cx_gainK_.dot(cx_gainK_) * B_(2));
+          cx_gainK_ * r.x() / (cx_gainK_.dot(cx_gainK_) * B_(2));
       eVector3 stateTrackingError_clamped_y =
-        cy_gainK_ * r.y() / (cy_gainK_.dot(cy_gainK_) * B_(2));
+          cy_gainK_ * r.y() / (cy_gainK_.dot(cy_gainK_) * B_(2));
 
       eVector3 nextStateTrackingError_clamped_x =
-        A_ * stateTrackingError_x +
-        B_ * cx_gainK_.transpose() * stateTrackingError_clamped_x;
+          A_ * stateTrackingError_x +
+          B_ * cx_gainK_.transpose() * stateTrackingError_clamped_x;
       eVector3 nextStateTrackingError_clamped_y =
-        A_ * stateTrackingError_y +
-        B_ * cy_gainK_.transpose() * stateTrackingError_clamped_y;
+          A_ * stateTrackingError_y +
+          B_ * cy_gainK_.transpose() * stateTrackingError_clamped_y;
 
       nextState_x = nextRefState_x + nextStateTrackingError_clamped_x;
       nextState_y = nextRefState_y + nextStateTrackingError_clamped_y;
@@ -337,11 +331,11 @@ void CopStabilizer::stabilizeCOP( // Not supported
   desired_com << nextState_x(0), nextState_y(0), reference_com.z();
   desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
   desired_com_acc << w2_ * (nextState_x(0) - nextState_x(2)),
-    w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
+      w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
   desired_icp << nextState_x(0) + nextState_x(1) / w_,
-    nextState_y(0) + nextState_y(1) / w_, 0.;
+      nextState_y(0) + nextState_y(1) / w_, 0.;
   actual_icp << actualState_x(0) + actualState_x(1) / w_,
-    actualState_y(0) + actualState_y(1) / w_, 0.;
+      actualState_y(0) + actualState_y(1) / w_, 0.;
   desired_cop_reference << referenceState_x(2), referenceState_y(2), 0.;
   desired_cop_computed << nextState_x(2), nextState_y(2), 0.;
 
@@ -362,10 +356,10 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   // ROS_INFO("Call stabilize approx acceleration");
   if (!configured_) {
     throw std::runtime_error(
-            "Stabilizer not initialized, please call the constructor with "
-            "arguments first");
+        "Stabilizer not initialized, please call the constructor with "
+        "arguments first");
   }
-  const double & dt = settings_.dt;
+  const double& dt = settings_.dt;
 
   target_com_ = reference_com;
   target_com_vel_ = reference_com_vel;
@@ -374,30 +368,30 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   // REFERENCE
   static Eigen::Vector3d old_reference_com_acc = reference_com_acc;
   Eigen::Vector3d reference_com_jerky(
-    (reference_com_acc - old_reference_com_acc) / dt);
+      (reference_com_acc - old_reference_com_acc) / dt);
   Eigen::Vector3d reference_com_jerk(
-    movingAverage(reference_com_jerky, 5, jerk_ma_queue_));
+      movingAverage(reference_com_jerky, 5, jerk_ma_queue_));
   Eigen::Vector2d referenceCCOP(reference_com.head<2>() -
-    reference_com_acc.head<2>() / w2_);
+                                reference_com_acc.head<2>() / w2_);
   Eigen::Vector2d referenceCCOP_vel(reference_com_vel.head<2>() -
-    reference_com_jerk.head<2>() / w2_);
+                                    reference_com_jerk.head<2>() / w2_);
   Eigen::Vector3d referenceState_x(reference_com.x(), reference_com_vel.x(),
-    referenceCCOP.x());
+                                   referenceCCOP.x());
   Eigen::Vector3d referenceState_y(reference_com.y(), reference_com_vel.y(),
-    referenceCCOP.y());
+                                   referenceCCOP.y());
 
   // REAL
   Eigen::Vector3d actualState_x(actual_com.x(), actual_com_vel.x(),
-    actual_cop.x());
+                                actual_cop.x());
   Eigen::Vector3d actualState_y(actual_com.y(), actual_com_vel.y(),
-    actual_cop.y());
+                                actual_cop.y());
 
   // TRACKING
   Eigen::Vector3d stateTrackingError_x(actualState_x - referenceState_x);
   Eigen::Vector3d stateTrackingError_y(actualState_y - referenceState_y);
   Eigen::Vector2d feedbackTerm;
   feedbackTerm << cx_gainK_.transpose() * stateTrackingError_x,
-    cy_gainK_.transpose() * stateTrackingError_y;
+      cy_gainK_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM
@@ -409,7 +403,7 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
     errorSum += actual_cop.head<2>() - referenceCCOP;
 
     Eigen::Vector2d integral_signal(
-      (settings_.integral_gain.array() * errorSum.array()).matrix());
+        (settings_.integral_gain.array() * errorSum.array()).matrix());
     feedbackTerm += integral_signal;
   }
   Eigen::Vector2d commandedCCOP_vel(referenceCCOP_vel + feedbackTerm);
@@ -422,7 +416,7 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   if (settings_.saturate_cop) {
     getNonLinearPart(actual_com, actual_com_acc, actual_cop, non_linear_);
     Eigen::Vector2d COP_unclamped(nextState_x(2) + non_linear_(0),
-      nextState_y(2) + non_linear_(1));
+                                  nextState_y(2) + non_linear_(1));
 
     if (!isPointInPolygon(COP_unclamped, support_polygon)) {
       // ROS_INFO("[com_control_utils] COP_unclamped not in the support polygon
@@ -432,16 +426,16 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
       projectCOPinSupportPolygon(COP_unclamped, support_polygon, COP_clamped);
 
       eVector3 nextRefState_x(A_ * referenceState_x +
-        B_ * referenceCCOP_vel.x());
+                              B_ * referenceCCOP_vel.x());
       eVector3 nextRefState_y(A_ * referenceState_y +
-        B_ * referenceCCOP_vel.y());
+                              B_ * referenceCCOP_vel.y());
       eVector2 nextRefCCOP(nextRefState_x(2), nextRefState_y(2));
       eVector2 LA_trErr_0(A_.block<1, 3>(2, 0) * stateTrackingError_x,
-        A_.block<1, 3>(2, 0) * stateTrackingError_y);
+                          A_.block<1, 3>(2, 0) * stateTrackingError_y);
 
       eVector2 saturatedFeedbackTerm =
-        (COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0) /
-        B_(2);
+          (COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0) /
+          B_(2);
       commandedCCOP_vel = referenceCCOP_vel + saturatedFeedbackTerm;
 
       nextState_x = A_ * actualState_x + B_ * commandedCCOP_vel.x();
@@ -452,11 +446,11 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   desired_com << nextState_x(0), nextState_y(0), reference_com.z();
   desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
   desired_com_acc << w2_ * (nextState_x(0) - nextState_x(2)),
-    w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
+      w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
   desired_icp << nextState_x(0) + nextState_x(1) / w_,
-    nextState_y(0) + nextState_y(1) / w_, 0.;
+      nextState_y(0) + nextState_y(1) / w_, 0.;
   actual_icp << actualState_x(0) + actualState_x(1) / w_,
-    actualState_y(0) + actualState_y(1) / w_, 0.;
+      actualState_y(0) + actualState_y(1) / w_, 0.;
   desired_cop_reference << referenceState_x(2), referenceState_y(2), 0.;
   desired_cop_computed << nextState_x(2), nextState_y(2), 0.;
 
@@ -477,8 +471,8 @@ void CopStabilizer::stabilizeP_CC(
   // ROS_INFO("Call stabilizeCCOP");
   if (!configured_) {
     throw std::runtime_error(
-            "Stabilizer not initialized, please call the constructor with "
-            "arguments first");
+        "Stabilizer not initialized, please call the constructor with "
+        "arguments first");
   }
 
   target_com_ = reference_com;
@@ -490,12 +484,12 @@ void CopStabilizer::stabilizeP_CC(
   }
   // REFERENCE
   const Eigen::Vector2d referenceCCOP(reference_com.head<2>() -
-    reference_com_acc.head<2>() / w2_);
+                                      reference_com_acc.head<2>() / w2_);
   target_cop_ = referenceCCOP;
   const Eigen::Vector2d referenceState_x(reference_com.x(),
-    reference_com_vel.x());
+                                         reference_com_vel.x());
   const Eigen::Vector2d referenceState_y(reference_com.y(),
-    reference_com_vel.y());
+                                         reference_com_vel.y());
 
   // REAL
   actualState2d_x_ = eVector2(actual_com.x(), actual_com_vel.x());
@@ -503,18 +497,18 @@ void CopStabilizer::stabilizeP_CC(
 
   // TRACKING
   const Eigen::Vector2d stateTrackingError_x(actualState2d_x_ -
-    referenceState_x);
+                                             referenceState_x);
   const Eigen::Vector2d stateTrackingError_y(actualState2d_y_ -
-    referenceState_y);
+                                             referenceState_y);
 
   estimated_disturbance_[0] = estimateCopDisturbance(
-    stateTrackingError_x, oldTrackingError2_x_, cx_gainK2_);
+      stateTrackingError_x, oldTrackingError2_x_, cx_gainK2_);
   estimated_disturbance_[1] = estimateCopDisturbance(
-    stateTrackingError_y, oldTrackingError2_y_, cy_gainK2_);
+      stateTrackingError_y, oldTrackingError2_y_, cy_gainK2_);
 
   Eigen::Vector2d feedbackTerm;
   feedbackTerm << cx_gainK2_.transpose() * stateTrackingError_x,
-    cy_gainK2_.transpose() * stateTrackingError_y;
+      cy_gainK2_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM (actually not in the DCM, it
@@ -529,7 +523,7 @@ void CopStabilizer::stabilizeP_CC(
     errorSum_ += actual_cop.head<2>() - referenceCCOP;
 
     Eigen::Vector2d integral_signal(
-      (settings_.integral_gain.array() * errorSum_.array()).matrix());
+        (settings_.integral_gain.array() * errorSum_.array()).matrix());
     feedbackTerm += integral_signal;
   }
   actual_command_ = (referenceCCOP + feedbackTerm);
@@ -542,9 +536,8 @@ void CopStabilizer::stabilizeP_CC(
       // ROS_INFO("[com_control_utils] COP_unclamped not in the support polygon
       // !");
       eVector2 COP_clamped;
-      projectCOPinSupportPolygon(
-        desired_uncampled_cop_, support_polygon,
-        COP_clamped);
+      projectCOPinSupportPolygon(desired_uncampled_cop_, support_polygon,
+                                 COP_clamped);
       actual_command_ = COP_clamped - non_linear_.head<2>();
     }
   }
@@ -557,11 +550,11 @@ void CopStabilizer::stabilizeP_CC(
   desired_com << nextState_x(0), nextState_y(0), reference_com.z();
   desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
   desired_com_acc << w2_ * (nextState_x(0) - actual_command_.x()),
-    w2_ * (nextState_y(0) - actual_command_.y()), reference_com_acc.z();
+      w2_ * (nextState_y(0) - actual_command_.y()), reference_com_acc.z();
   desired_icp << nextState_x(0) + nextState_x(1) / w_,
-    nextState_y(0) + nextState_y(1) / w_, 0.;
+      nextState_y(0) + nextState_y(1) / w_, 0.;
   actual_icp << actualState2d_x_(0) + actualState2d_x_(1) / w_,
-    actualState2d_y_(0) + actualState2d_y_(1) / w_, 0.;
+      actualState2d_y_(0) + actualState2d_y_(1) / w_, 0.;
   desired_cop_reference << referenceCCOP + non_linear_.head<2>(), 0.;
   desired_cop_computed << actual_command_ + non_linear_.head<2>(), 0.;
 }
@@ -584,33 +577,33 @@ void CopStabilizer::stabilizeJerk(
 
   // REFERENCE
   const eVector3 referenceState_x(reference_com.x(), reference_com_vel.x(),
-    reference_com_acc.x());
+                                  reference_com_acc.x());
   const eVector3 referenceState_y(reference_com.y(), reference_com_vel.y(),
-    reference_com_acc.y());
+                                  reference_com_acc.y());
   const eVector2 referenceCCOP(reference_com.head<2>() -
-    reference_com_acc.head<2>() / (w2_));
+                               reference_com_acc.head<2>() / (w2_));
   target_cop_ = referenceCCOP;
 
   // REAL
   actualState3d_x_ =
-    eVector3(actual_com.x(), actual_com_vel.x(), actual_com_acc.x());
+      eVector3(actual_com.x(), actual_com_vel.x(), actual_com_acc.x());
   actualState3d_y_ =
-    eVector3(actual_com.y(), actual_com_vel.y(), actual_com_acc.y());
+      eVector3(actual_com.y(), actual_com_vel.y(), actual_com_acc.y());
 
   // TRACKING
   const Eigen::Vector3d stateTrackingError_x(actualState3d_x_ -
-    referenceState_x);
+                                             referenceState_x);
   const Eigen::Vector3d stateTrackingError_y(actualState3d_y_ -
-    referenceState_y);
+                                             referenceState_y);
 
   estimated_disturbance_[0] = estimateJerkDisturbance(
-    stateTrackingError_x, oldTrackingError_x_, cx_gainK_);
+      stateTrackingError_x, oldTrackingError_x_, cx_gainK_);
   estimated_disturbance_[1] = estimateJerkDisturbance(
-    stateTrackingError_y, oldTrackingError_y_, cy_gainK_);
+      stateTrackingError_y, oldTrackingError_y_, cy_gainK_);
 
   Eigen::Vector2d feedbackTerm;
   feedbackTerm << cx_gainK_.transpose() * stateTrackingError_x,
-    cy_gainK_.transpose() * stateTrackingError_y;
+      cy_gainK_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM
@@ -621,44 +614,42 @@ void CopStabilizer::stabilizeJerk(
     errorSum_ += actual_cop.head<2>() - referenceCCOP;
 
     Eigen::Vector2d integral_signal(
-      (settings_.integral_gain.array() * errorSum_.array()).matrix());
+        (settings_.integral_gain.array() * errorSum_.array()).matrix());
     feedbackTerm += integral_signal;
   }
   actual_command_ = eVector2(reference_com_jerk.head<2>() + feedbackTerm);
   Eigen::Vector3d nextState_x(Aj_ * actualState3d_x_ +
-    Bj_ * actual_command_.x());
+                              Bj_ * actual_command_.x());
   Eigen::Vector3d nextState_y(Aj_ * actualState3d_y_ +
-    Bj_ * actual_command_.y());
+                              Bj_ * actual_command_.y());
 
   getNonLinearPart(actual_com, actual_com_acc, actual_cop, non_linear_);
   desired_uncampled_cop_ =
-    eVector2(
-    nextState_x(0) - nextState_x(2) / w2_ + non_linear_(0),
-    nextState_y(0) - nextState_y(2) / w2_ + non_linear_(1));
+      eVector2(nextState_x(0) - nextState_x(2) / w2_ + non_linear_(0),
+               nextState_y(0) - nextState_y(2) / w2_ + non_linear_(1));
   if (settings_.saturate_cop) {
     if (!isPointInPolygon(desired_uncampled_cop_, support_polygon)) {
       // ROS_INFO("[com_control_utils] COP_unclamped not in the support polygon
       // !");
 
       eVector2 COP_clamped;
-      projectCOPinSupportPolygon(
-        desired_uncampled_cop_, support_polygon,
-        COP_clamped);
+      projectCOPinSupportPolygon(desired_uncampled_cop_, support_polygon,
+                                 COP_clamped);
 
       const eVector3 nextRefState_x(Aj_ * referenceState_x +
-        Bj_ * reference_com_jerk.x());
+                                    Bj_ * reference_com_jerk.x());
       const eVector3 nextRefState_y(Aj_ * referenceState_y +
-        Bj_ * reference_com_jerk.y());
+                                    Bj_ * reference_com_jerk.y());
       const eVector2 nextRefCCOP(nextRefState_x(0) - nextRefState_x(2) / w2_,
-        nextRefState_y(0) - nextRefState_y(2) / w2_);
+                                 nextRefState_y(0) - nextRefState_y(2) / w2_);
       eVector3 L;
       L << 1, 0, -1 / w2_;
       const eVector2 LA_trErr_0(L.transpose() * Aj_ * stateTrackingError_x,
-        L.transpose() * Aj_ * stateTrackingError_y);
+                                L.transpose() * Aj_ * stateTrackingError_y);
 
       const eVector2 saturatedFeedbackTerm =
-        (COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0) /
-        (L.transpose() * Bj_);
+          (COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0) /
+          (L.transpose() * Bj_);
       actual_command_ = reference_com_jerk.head<2>() + saturatedFeedbackTerm;
 
       nextState_x = Aj_ * actualState3d_x_ + Bj_ * actual_command_.x();
@@ -670,78 +661,68 @@ void CopStabilizer::stabilizeJerk(
   desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
   desired_com_acc << nextState_x(2), nextState_y(2), reference_com_acc.z();
   desired_icp << nextState_x(0) + nextState_x(1) / w_,
-    nextState_y(0) + nextState_y(1) / w_, 0.;
+      nextState_y(0) + nextState_y(1) / w_, 0.;
   actual_icp << actualState3d_x_(0) + actualState3d_x_(1) / w_,
-    actualState3d_y_(0) + actualState3d_y_(1) / w_, 0.;
+      actualState3d_y_(0) + actualState3d_y_(1) / w_, 0.;
   desired_cop_reference << referenceCCOP.x() + non_linear_.x(),
-    referenceCCOP.y() + non_linear_.y(), 0.;
+      referenceCCOP.y() + non_linear_.y(), 0.;
   desired_cop_computed << nextState_x(0) - nextState_x(2) / w2_ +
-    non_linear_.x(),
-    nextState_y(0) - nextState_y(2) / w2_ + non_linear_.y(), 0.;
+                              non_linear_.x(),
+      nextState_y(0) - nextState_y(2) / w2_ + non_linear_.y(), 0.;
 }
 
 double CopStabilizer::distributeForces(
-  const eVector2 & desired_cop, const eVector2 LF_xy, const double LF_force_z,
-  const eVector2 LF_torque_xy, const eVector2 RF_xy, const double RF_force_z,
-  const eVector2 RF_torque_xy)
-{
+    const eVector2& desired_cop, const eVector2 LF_xy, const double LF_force_z,
+    const eVector2 LF_torque_xy, const eVector2 RF_xy, const double RF_force_z,
+    const eVector2 RF_torque_xy) {
   Eigen::Vector2d cop_L(LF_xy + RotPi_2_ * LF_torque_xy / LF_force_z);
   Eigen::Vector2d cop_R(RF_xy + RotPi_2_ * RF_torque_xy / RF_force_z);
 
   return (desired_cop - cop_R).norm() / (cop_L - cop_R).norm();
 }
 
-std::array<eVector3, 3> CopStabilizer::getStableCoMs(const double & com_height)
-{
+std::array<eVector3, 3> CopStabilizer::getStableCoMs(const double& com_height) {
   if (settings_.cop_control_type == "p_cc") {
-    return {{eVector3(
-        S_coms_.block<1, 2>(0, 0) * actualState2d_x_ +
-        U_coms_(0) * actual_command_.x(),
-        S_coms_.block<1, 2>(0, 0) * actualState2d_y_ +
-        U_coms_(0) * actual_command_.y(),
-        com_height),
-      eVector3(
-        S_coms_.block<1, 2>(1, 0) * actualState2d_x_ +
-        U_coms_(1) * actual_command_.x(),
-        S_coms_.block<1, 2>(1, 0) * actualState2d_y_ +
-        U_coms_(1) * actual_command_.y(),
-        com_height),
-      eVector3(
-        S_coms_.block<1, 2>(2, 0) * actualState2d_x_ +
-        U_coms_(2) * actual_command_.x(),
-        S_coms_.block<1, 2>(2, 0) * actualState2d_y_ +
-        U_coms_(2) * actual_command_.y(),
-        com_height)}};
+    return {{eVector3(S_coms_.block<1, 2>(0, 0) * actualState2d_x_ +
+                          U_coms_(0) * actual_command_.x(),
+                      S_coms_.block<1, 2>(0, 0) * actualState2d_y_ +
+                          U_coms_(0) * actual_command_.y(),
+                      com_height),
+             eVector3(S_coms_.block<1, 2>(1, 0) * actualState2d_x_ +
+                          U_coms_(1) * actual_command_.x(),
+                      S_coms_.block<1, 2>(1, 0) * actualState2d_y_ +
+                          U_coms_(1) * actual_command_.y(),
+                      com_height),
+             eVector3(S_coms_.block<1, 2>(2, 0) * actualState2d_x_ +
+                          U_coms_(2) * actual_command_.x(),
+                      S_coms_.block<1, 2>(2, 0) * actualState2d_y_ +
+                          U_coms_(2) * actual_command_.y(),
+                      com_height)}};
   } else if (settings_.cop_control_type == "j_ccc") {
-    return {{eVector3(
-        S_coms_j_.block<1, 3>(0, 0) * actualState3d_x_ +
-        U_coms_j_(0) * actual_command_.x(),
-        S_coms_j_.block<1, 3>(0, 0) * actualState3d_y_ +
-        U_coms_j_(0) * actual_command_.y(),
-        com_height),
-      eVector3(
-        S_coms_j_.block<1, 3>(1, 0) * actualState3d_x_ +
-        U_coms_j_(1) * actual_command_.x(),
-        S_coms_j_.block<1, 3>(1, 0) * actualState3d_y_ +
-        U_coms_j_(1) * actual_command_.y(),
-        com_height),
-      eVector3(
-        S_coms_j_.block<1, 3>(2, 0) * actualState3d_x_ +
-        U_coms_j_(2) * actual_command_.x(),
-        S_coms_j_.block<1, 3>(2, 0) * actualState3d_y_ +
-        U_coms_j_(2) * actual_command_.y(),
-        com_height)}};
+    return {{eVector3(S_coms_j_.block<1, 3>(0, 0) * actualState3d_x_ +
+                          U_coms_j_(0) * actual_command_.x(),
+                      S_coms_j_.block<1, 3>(0, 0) * actualState3d_y_ +
+                          U_coms_j_(0) * actual_command_.y(),
+                      com_height),
+             eVector3(S_coms_j_.block<1, 3>(1, 0) * actualState3d_x_ +
+                          U_coms_j_(1) * actual_command_.x(),
+                      S_coms_j_.block<1, 3>(1, 0) * actualState3d_y_ +
+                          U_coms_j_(1) * actual_command_.y(),
+                      com_height),
+             eVector3(S_coms_j_.block<1, 3>(2, 0) * actualState3d_x_ +
+                          U_coms_j_(2) * actual_command_.x(),
+                      S_coms_j_.block<1, 3>(2, 0) * actualState3d_y_ +
+                          U_coms_j_(2) * actual_command_.y(),
+                      com_height)}};
   } else {
     throw std::runtime_error(
-            "Invalid control type in CopStabilizer::getStableCoMs");
+        "Invalid control type in CopStabilizer::getStableCoMs");
   }
 }
 
-template<typename T, typename vec_T>
-T CopStabilizer::movingAverage(
-  const T x, const unsigned long nb_samples,
-  vec_T & queue)
-{
+template <typename T, typename vec_T>
+T CopStabilizer::movingAverage(const T x, const unsigned long nb_samples,
+                               vec_T& queue) {
   if (queue.capacity() < nb_samples) {
     queue.reserve(nb_samples);
   }
@@ -752,81 +733,71 @@ T CopStabilizer::movingAverage(
     n--;
   }
   T summation = 0 * x;
-  for (T & element : queue) {
+  for (T& element : queue) {
     summation += element;
   }
   return summation / n;
 }
 
 void CopStabilizer::getNonLinearPart(
-  const eVector6 & leftFootWrench, const eVector6 & rightFootWrench,
-  const Eigen::Vector2d & leftFootPlace, const Eigen::Vector2d & rightFootPlace,
-  const Eigen::Vector2d & CoM, const Eigen::Vector2d & lateral_gravity,
-  const Eigen::Vector2d & externalForce, eVector3 & n)
-{
-  const double & m = settings_.robot_mass;
+    const eVector6& leftFootWrench, const eVector6& rightFootWrench,
+    const Eigen::Vector2d& leftFootPlace, const Eigen::Vector2d& rightFootPlace,
+    const Eigen::Vector2d& CoM, const Eigen::Vector2d& lateral_gravity,
+    const Eigen::Vector2d& externalForce, eVector3& n) {
+  const double& m = settings_.robot_mass;
   Eigen::Vector2d CoM_acc =
-    (leftFootWrench.head<2>() + rightFootWrench.head<2>() + externalForce) /
-    m +
-    lateral_gravity;
+      (leftFootWrench.head<2>() + rightFootWrench.head<2>() + externalForce) /
+          m +
+      lateral_gravity;
   Eigen::Vector2d leftFootPlace_c = leftFootPlace - CoM;
   Eigen::Vector2d rightFootPlace_c = rightFootPlace - CoM;
-  getNonLinearPart(
-    leftFootWrench, rightFootWrench, leftFootPlace_c,
-    rightFootPlace_c, CoM_acc, n);
+  getNonLinearPart(leftFootWrench, rightFootWrench, leftFootPlace_c,
+                   rightFootPlace_c, CoM_acc, n);
 }
 
 void CopStabilizer::getNonLinearPart(
-  const eVector6 & leftFootWrench, const eVector6 & rightFootWrench,
-  const Eigen::Vector2d & leftFootPlace, const Eigen::Vector2d & rightFootPlace,
-  const Eigen::Vector2d & CoM, const Eigen::Vector2d & CoM_acc, eVector3 & n)
-{
+    const eVector6& leftFootWrench, const eVector6& rightFootWrench,
+    const Eigen::Vector2d& leftFootPlace, const Eigen::Vector2d& rightFootPlace,
+    const Eigen::Vector2d& CoM, const Eigen::Vector2d& CoM_acc, eVector3& n) {
   /**
    * FeetWrenches are sorted as [force_x, force_y, force_z, torque_x, torque_y,
    * torque_z]
    */
   Eigen::Vector2d leftFootPlace_c = leftFootPlace - CoM;
   Eigen::Vector2d rightFootPlace_c = rightFootPlace - CoM;
-  getNonLinearPart(
-    leftFootWrench, rightFootWrench, leftFootPlace_c,
-    rightFootPlace_c, CoM_acc, n);
+  getNonLinearPart(leftFootWrench, rightFootWrench, leftFootPlace_c,
+                   rightFootPlace_c, CoM_acc, n);
 }
 
-void CopStabilizer::getNonLinearPart(
-  const eVector6 & leftFootWrench,
-  const eVector6 & rightFootWrench,
-  const Eigen::Vector2d & leftFootPlace_c,
-  const Eigen::Vector2d & rightFootPlace_c,
-  const Eigen::Vector2d & CoM_acc,
-  eVector3 & n)
-{
+void CopStabilizer::getNonLinearPart(const eVector6& leftFootWrench,
+                                     const eVector6& rightFootWrench,
+                                     const Eigen::Vector2d& leftFootPlace_c,
+                                     const Eigen::Vector2d& rightFootPlace_c,
+                                     const Eigen::Vector2d& CoM_acc,
+                                     eVector3& n) {
   /**
    * FeetWrenches are sorted as [force_x, force_y, force_z, torque_x, torque_y,
    * torque_z] FeetPlaces_c are the feet places measured from the CoM of the
    * robot.
    */
   n << (CoM_acc) / w2_ + (leftFootWrench.block<2, 1>(3, 0) +
-  rightFootWrench.block<2, 1>(3, 0) +
-  leftFootPlace_c * leftFootWrench(2) +
-  rightFootPlace_c * rightFootWrench(2)) /
-    (leftFootWrench(2) + rightFootWrench(2)),
-    0;
+                          rightFootWrench.block<2, 1>(3, 0) +
+                          leftFootPlace_c * leftFootWrench(2) +
+                          rightFootPlace_c * rightFootWrench(2)) /
+                             (leftFootWrench(2) + rightFootWrench(2)),
+      0;
 }
 
-void CopStabilizer::getNonLinearPart(
-  const eVector3 & com,
-  const eVector3 & com_acc,
-  const eVector2 & cop, eVector3 & n)
-{
+void CopStabilizer::getNonLinearPart(const eVector3& com,
+                                     const eVector3& com_acc,
+                                     const eVector2& cop, eVector3& n) {
   n << cop.head<2>() - (com.head<2>() - (com_acc.head<2>()) / w2_), 0;
 }
 
-void CopStabilizer::getNonLinearPart(eVector3 & n) {n.fill(0.0);}
+void CopStabilizer::getNonLinearPart(eVector3& n) { n.fill(0.0); }
 
-bool CopStabilizer::isPointInPolygon(
-  const eVector2 & point,
-  const Polygon2D & polygon)
-{
+bool CopStabilizer::isPointInPolygon(const eVector2& point,
+                                     const Polygon2D& polygon) {
   wykobi_2d_point_.x = point.x();
   wykobi_2d_point_.y = point.y();
   return wykobi::point_in_convex_polygon(wykobi_2d_point_, polygon);
@@ -837,7 +808,7 @@ CopStabilizer::estimateJerkDisturbance(const eVector3 &currentTrackingError,
                                        eVector3 &oldTrackingError,
                                        const eVector3 &c_gainK) {
   eVector3 B_ej(currentTrackingError -
-    (A_ + B_ * c_gainK.transpose()) * oldTrackingError);
+                (A_ + B_ * c_gainK.transpose()) * oldTrackingError);
   oldTrackingError = currentTrackingError;
   return ((B_.transpose() * B_ej) / (B_.transpose() * B_))(0);
 }
@@ -847,31 +818,27 @@ CopStabilizer::estimateCopDisturbance(const eVector2 &currentTrackingError,
                                       eVector2 &oldTrackingError,
                                       const eVector2 &c_gainK) {
   eVector2 B_ej(currentTrackingError -
-    (A22_ + B2_ * c_gainK.transpose()) * oldTrackingError);
+                (A22_ + B2_ * c_gainK.transpose()) * oldTrackingError);
   double v = ((B2_.transpose() * B_ej) / (B2_.transpose() * B2_))(0);
   oldTrackingError = currentTrackingError;
   return v;
 }
 
-void CopStabilizer::setCOPgains(
-  const eVector3 & cop_x_gains,
-  const eVector3 & cop_y_gains)
-{
+void CopStabilizer::setCOPgains(const eVector3& cop_x_gains,
+                                const eVector3& cop_y_gains) {
   settings_.cop_x_gains = cop_x_gains;
   settings_.cop_y_gains = cop_y_gains;
   cx_gainK_ = settings_.cop_x_gains;
   cy_gainK_ = settings_.cop_y_gains;
 }
 
-void CopStabilizer::setPCCgains(const double cop_pcc_gains)
-{
+void CopStabilizer::setPCCgains(const double cop_pcc_gains) {
   settings_.cop_p_cc_gain = cop_pcc_gains;
   cx_gainK2_ << settings_.cop_p_cc_gain, settings_.cop_p_cc_gain / w_;
   cy_gainK2_ << settings_.cop_p_cc_gain, settings_.cop_p_cc_gain / w_;
 }
 
-void CopStabilizer::setIntegralGains(const eVector2 & integral_gains)
-{
+void CopStabilizer::setIntegralGains(const eVector2& integral_gains) {
   settings_.integral_gain = integral_gains;
 }
 

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -144,8 +144,10 @@ void CopStabilizer::stabilize(
             reference_com_acc, reference_com_jerk, desired_com, desired_com_vel,
             desired_com_acc, desired_icp, actual_icp, desired_cop_reference_2d,
             desired_cop_computed_2d);
-  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
-  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
+  desired_cop_reference =
+      eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed =
+      eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilize(
@@ -189,8 +191,10 @@ void CopStabilizer::stabilize(
             reference_com_acc, reference_com_jerk, desired_com, desired_com_vel,
             desired_com_acc, desired_icp, actual_icp, desired_cop_reference_2d,
             desired_cop_computed_2d);
-  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
-  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
+  desired_cop_reference =
+      eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed =
+      eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilize(
@@ -218,16 +222,16 @@ void CopStabilizer::stabilize(
                   desired_cop_reference, desired_cop_computed);
   } else if (settings_.cop_control_type == "approximated_acceleration") {
     stabilizeApproximateAcceleration(
-      actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
-      reference_com, reference_com_vel, reference_com_acc, desired_com,
-      desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-      desired_cop_reference, desired_cop_computed);
+        actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
+        reference_com, reference_com_vel, reference_com_acc, desired_com,
+        desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+        desired_cop_reference, desired_cop_computed);
   } else if (settings_.cop_control_type == "j_ccc") {
-    stabilizeJerk(
-      actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
-      reference_com, reference_com_vel, reference_com_acc, reference_com_jerk,
-      desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-      desired_cop_reference, desired_cop_computed);
+    stabilizeJerk(actual_com, actual_com_vel, actual_com_acc, actual_cop,
+                  support_polygon, reference_com, reference_com_vel,
+                  reference_com_acc, reference_com_jerk, desired_com,
+                  desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+                  desired_cop_reference, desired_cop_computed);
   } else {
     throw std::runtime_error("Invalid cop control type, got : " +
                              settings_.cop_control_type);
@@ -252,8 +256,10 @@ void CopStabilizer::stabilizeCOP( // Not supported
                reference_com_acc, desired_com, desired_com_vel, desired_com_acc,
                desired_icp, actual_icp, desired_cop_reference_2d,
                desired_cop_computed_2d);
-  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
-  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
+  desired_cop_reference =
+      eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed =
+      eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilizeCOP( // Not supported
@@ -388,8 +394,10 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
       support_polygon, reference_com, reference_com_vel, reference_com_acc,
       desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
       desired_cop_reference_2d, desired_cop_computed_2d);
-  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
-  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
+  desired_cop_reference =
+      eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed =
+      eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
@@ -523,8 +531,10 @@ void CopStabilizer::stabilizeP_CC(
                 reference_com_acc, desired_com, desired_com_vel,
                 desired_com_acc, desired_icp, actual_icp,
                 desired_cop_reference_2d, desired_cop_computed_2d);
-  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
-  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
+  desired_cop_reference =
+      eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed =
+      eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilizeP_CC(
@@ -646,8 +656,10 @@ void CopStabilizer::stabilizeJerk(
                 reference_com_acc, reference_com_jerk, desired_com,
                 desired_com_vel, desired_com_acc, desired_icp, actual_icp,
                 desired_cop_reference_2d, desired_cop_computed_2d);
-  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
-  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
+  desired_cop_reference =
+      eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed =
+      eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilizeJerk(

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -144,14 +144,8 @@ void CopStabilizer::stabilize(
             reference_com_acc, reference_com_jerk, desired_com, desired_com_vel,
             desired_com_acc, desired_icp, actual_icp, desired_cop_reference_2d,
             desired_cop_computed_2d);
-  desired_cop_reference.head<2>() = desired_cop_reference_2d;
-  desired_cop_reference.z() = 0.0;
-  desired_cop_computed.head<2>() = desired_cop_reference_2d;
-  desired_cop_computed.z() = 0.0;
-  std::cout << "desired_cop_reference: " << desired_cop_reference.transpose()
-            << std::endl;
-  std::cout << "desired_cop_computed: " << desired_cop_computed.transpose()
-            << std::endl;
+  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilize(
@@ -195,10 +189,8 @@ void CopStabilizer::stabilize(
             reference_com_acc, reference_com_jerk, desired_com, desired_com_vel,
             desired_com_acc, desired_icp, actual_icp, desired_cop_reference_2d,
             desired_cop_computed_2d);
-  desired_cop_reference.head<2>() = desired_cop_reference_2d;
-  desired_cop_reference.z() = 0.0;
-  desired_cop_computed.head<2>() = desired_cop_reference_2d;
-  desired_cop_computed.z() = 0.0;
+  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilize(
@@ -213,29 +205,29 @@ void CopStabilizer::stabilize(
     eVector2 &desired_cop_reference, // ???
     eVector2 &desired_cop_computed) {
   if (settings_.cop_control_type == "cop") {
-    return stabilizeCOP(actual_com, actual_com_vel, actual_com_acc, actual_cop,
-                        support_polygon, reference_com, reference_com_vel,
-                        reference_com_acc, desired_com, desired_com_vel,
-                        desired_com_acc, desired_icp, actual_icp,
-                        desired_cop_reference, desired_cop_computed);
+    stabilizeCOP(actual_com, actual_com_vel, actual_com_acc, actual_cop,
+                 support_polygon, reference_com, reference_com_vel,
+                 reference_com_acc, desired_com, desired_com_vel,
+                 desired_com_acc, desired_icp, actual_icp,
+                 desired_cop_reference, desired_cop_computed);
   } else if (settings_.cop_control_type == "p_cc") {
-    return stabilizeP_CC(actual_com, actual_com_vel, actual_com_acc, actual_cop,
-                         support_polygon, reference_com, reference_com_vel,
-                         reference_com_acc, desired_com, desired_com_vel,
-                         desired_com_acc, desired_icp, actual_icp,
-                         desired_cop_reference, desired_cop_computed);
+    stabilizeP_CC(actual_com, actual_com_vel, actual_com_acc, actual_cop,
+                  support_polygon, reference_com, reference_com_vel,
+                  reference_com_acc, desired_com, desired_com_vel,
+                  desired_com_acc, desired_icp, actual_icp,
+                  desired_cop_reference, desired_cop_computed);
   } else if (settings_.cop_control_type == "approximated_acceleration") {
-    return stabilizeApproximateAcceleration(
-        actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
-        reference_com, reference_com_vel, reference_com_acc, desired_com,
-        desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-        desired_cop_reference, desired_cop_computed);
+    stabilizeApproximateAcceleration(
+      actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
+      reference_com, reference_com_vel, reference_com_acc, desired_com,
+      desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+      desired_cop_reference, desired_cop_computed);
   } else if (settings_.cop_control_type == "j_ccc") {
-    return stabilizeJerk(
-        actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
-        reference_com, reference_com_vel, reference_com_acc, reference_com_jerk,
-        desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-        desired_cop_reference, desired_cop_computed);
+    stabilizeJerk(
+      actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
+      reference_com, reference_com_vel, reference_com_acc, reference_com_jerk,
+      desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+      desired_cop_reference, desired_cop_computed);
   } else {
     throw std::runtime_error("Invalid cop control type, got : " +
                              settings_.cop_control_type);
@@ -260,10 +252,8 @@ void CopStabilizer::stabilizeCOP( // Not supported
                reference_com_acc, desired_com, desired_com_vel, desired_com_acc,
                desired_icp, actual_icp, desired_cop_reference_2d,
                desired_cop_computed_2d);
-  desired_cop_reference.head<2>() = desired_cop_reference_2d;
-  desired_cop_reference.z() = 0.0;
-  desired_cop_computed.head<2>() = desired_cop_reference_2d;
-  desired_cop_computed.z() = 0.0;
+  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilizeCOP( // Not supported
@@ -398,10 +388,8 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
       support_polygon, reference_com, reference_com_vel, reference_com_acc,
       desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
       desired_cop_reference_2d, desired_cop_computed_2d);
-  desired_cop_reference.head<2>() = desired_cop_reference_2d;
-  desired_cop_reference.z() = 0.0;
-  desired_cop_computed.head<2>() = desired_cop_reference_2d;
-  desired_cop_computed.z() = 0.0;
+  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
@@ -535,10 +523,8 @@ void CopStabilizer::stabilizeP_CC(
                 reference_com_acc, desired_com, desired_com_vel,
                 desired_com_acc, desired_icp, actual_icp,
                 desired_cop_reference_2d, desired_cop_computed_2d);
-  desired_cop_reference.head<2>() = desired_cop_reference_2d;
-  desired_cop_reference.z() = 0.0;
-  desired_cop_computed.head<2>() = desired_cop_reference_2d;
-  desired_cop_computed.z() = 0.0;
+  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilizeP_CC(
@@ -660,10 +646,8 @@ void CopStabilizer::stabilizeJerk(
                 reference_com_acc, reference_com_jerk, desired_com,
                 desired_com_vel, desired_com_acc, desired_icp, actual_icp,
                 desired_cop_reference_2d, desired_cop_computed_2d);
-  desired_cop_reference.head<2>() = desired_cop_reference_2d;
-  desired_cop_reference.z() = 0.0;
-  desired_cop_computed.head<2>() = desired_cop_reference_2d;
-  desired_cop_computed.z() = 0.0;
+  desired_cop_reference = eVector3(desired_cop_reference_2d.x(), desired_cop_reference_2d.y(), 0.0);
+  desired_cop_computed = eVector3(desired_cop_computed_2d.x(), desired_cop_computed_2d.y(), 0.0);
 }
 
 void CopStabilizer::stabilizeJerk(
@@ -905,7 +889,7 @@ void CopStabilizer::getNonLinearPart(const eVector6 &leftFootWrench,
 void CopStabilizer::getNonLinearPart(const eVector3 &com,
                                      const eVector3 &com_acc,
                                      const eVector2 &cop, eVector3 &n) {
-  n << cop.head<2>() - (com.head<2>() - (com_acc.head<2>()) / w2_), 0;
+  n << cop - (com.head<2>() - (com_acc.head<2>()) / w2_), 0;
 }
 
 void CopStabilizer::getNonLinearPart(eVector3 &n) { n.fill(0.0); }

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -18,9 +18,9 @@ CopStabilizer::CopStabilizer(const CopStabilizerSettings &settings)
 
 CopStabilizer::~CopStabilizer() {}
 
-void CopStabilizer::configure(const CopStabilizerSettings& settings) {
+void CopStabilizer::configure(const CopStabilizerSettings &settings) {
   settings_ = settings;
-  const double& dt = settings_.dt;
+  const double &dt = settings_.dt;
   configured_ = true;
   first_iter_ = true;
   w2_ = settings_.g / settings_.height;
@@ -88,8 +88,8 @@ void CopStabilizer::configure(const CopStabilizerSettings& settings) {
   jerk_ma_queue_.clear();
 }
 
-void CopStabilizer::computeSupportPolygon(const eMatrixHoms& stance_poses,
-                                          Polygon2D& convex_hull) {
+void CopStabilizer::computeSupportPolygon(const eMatrixHoms &stance_poses,
+                                          Polygon2D &convex_hull) {
   // Compute the global position of the feet edges.
   foot_description_.clear();
   for (size_t j = 0; j < stance_poses.size(); j++) {
@@ -111,8 +111,8 @@ void CopStabilizer::computeSupportPolygon(const eMatrixHoms& stance_poses,
 }
 
 void CopStabilizer::projectCOPinSupportPolygon(
-    const eVector2& target_cop_unclamped, const Polygon2D& polygon,
-    eVector2& target_cop) {
+    const eVector2 &target_cop_unclamped, const Polygon2D &polygon,
+    eVector2 &target_cop) {
   wykobi_cop_unclamped_.x = target_cop_unclamped.x();
   wykobi_cop_unclamped_.y = target_cop_unclamped.y();
   if (wykobi::point_in_convex_polygon(wykobi_cop_unclamped_, polygon)) {
@@ -142,8 +142,8 @@ void CopStabilizer::stabilize(
   stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop_2d,
             actual_stance_poses, reference_com, reference_com_vel,
             reference_com_acc, reference_com_jerk, desired_com, desired_com_vel,
-            desired_com_acc, desired_icp, actual_icp,
-            desired_cop_reference_2d, desired_cop_computed_2d);
+            desired_com_acc, desired_icp, actual_icp, desired_cop_reference_2d,
+            desired_cop_computed_2d);
 }
 
 void CopStabilizer::stabilize(
@@ -185,8 +185,8 @@ void CopStabilizer::stabilize(
   stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop_2d,
             support_polygon, reference_com, reference_com_vel,
             reference_com_acc, reference_com_jerk, desired_com, desired_com_vel,
-            desired_com_acc, desired_icp, actual_icp,
-            desired_cop_reference_2d, desired_cop_computed_2d);
+            desired_com_acc, desired_icp, actual_icp, desired_cop_reference_2d,
+            desired_cop_computed_2d);
 }
 
 void CopStabilizer::stabilize(
@@ -244,10 +244,10 @@ void CopStabilizer::stabilizeCOP( // Not supported
   eVector2 desired_cop_reference_2d = desired_cop_reference.head<2>();
   eVector2 desired_cop_computed_2d = desired_cop_computed.head<2>();
   stabilizeCOP(actual_com, actual_com_vel, actual_com_acc, actual_cop_2d,
-              support_polygon, reference_com, reference_com_vel, reference_com_acc,
-              desired_com, desired_com_vel, desired_com_acc,
-              desired_icp, actual_icp,
-              desired_cop_reference_2d, desired_cop_computed_2d);
+               support_polygon, reference_com, reference_com_vel,
+               reference_com_acc, desired_com, desired_com_vel, desired_com_acc,
+               desired_icp, actual_icp, desired_cop_reference_2d,
+               desired_cop_computed_2d);
 }
 
 void CopStabilizer::stabilizeCOP( // Not supported
@@ -265,7 +265,7 @@ void CopStabilizer::stabilizeCOP( // Not supported
         "Stabilizer not initialized, please call the constructor with "
         "arguments first");
   }
-  const double& dt = settings_.dt;
+  const double &dt = settings_.dt;
 
   target_com_ = reference_com;
   target_com_vel_ = reference_com_vel;
@@ -375,12 +375,11 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   eVector2 actual_cop_2d = actual_cop.head<2>();
   eVector2 desired_cop_reference_2d = desired_cop_reference.head<2>();
   eVector2 desired_cop_computed_2d = desired_cop_computed.head<2>();
-  stabilizeApproximateAcceleration(actual_com, actual_com_vel, actual_com_acc,
-                                   actual_cop_2d, support_polygon, reference_com,
-                                   reference_com_vel, reference_com_acc,
-                                   desired_com, desired_com_vel, desired_com_acc,
-                                   desired_icp, actual_icp,
-                                   desired_cop_reference_2d, desired_cop_computed_2d);
+  stabilizeApproximateAcceleration(
+      actual_com, actual_com_vel, actual_com_acc, actual_cop_2d,
+      support_polygon, reference_com, reference_com_vel, reference_com_acc,
+      desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+      desired_cop_reference_2d, desired_cop_computed_2d);
 }
 
 void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
@@ -398,7 +397,7 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
         "Stabilizer not initialized, please call the constructor with "
         "arguments first");
   }
-  const double& dt = settings_.dt;
+  const double &dt = settings_.dt;
 
   target_com_ = reference_com;
   target_com_vel_ = reference_com_vel;
@@ -508,9 +507,10 @@ void CopStabilizer::stabilizeP_CC(
   eVector2 desired_cop_reference_2d = desired_cop_reference.head<2>();
   eVector2 desired_cop_computed_2d = desired_cop_computed.head<2>();
   stabilizeP_CC(actual_com, actual_com_vel, actual_com_acc, actual_cop_2d,
-               support_polygon, reference_com, reference_com_vel, reference_com_acc,
-               desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-               desired_cop_reference_2d, desired_cop_computed_2d);
+                support_polygon, reference_com, reference_com_vel,
+                reference_com_acc, desired_com, desired_com_vel,
+                desired_com_acc, desired_icp, actual_icp,
+                desired_cop_reference_2d, desired_cop_computed_2d);
 }
 
 void CopStabilizer::stabilizeP_CC(
@@ -626,10 +626,10 @@ void CopStabilizer::stabilizeJerk(
   eVector2 desired_cop_reference_2d = desired_cop_reference.head<2>();
   eVector2 desired_cop_computed_2d = desired_cop_computed.head<2>();
   stabilizeJerk(actual_com, actual_com_vel, actual_com_acc, actual_cop_2d,
-               support_polygon, reference_com, reference_com_vel, reference_com_acc,
-               reference_com_jerk, desired_com, desired_com_vel, desired_com_acc,
-               desired_icp, actual_icp,
-               desired_cop_reference_2d, desired_cop_computed_2d);
+                support_polygon, reference_com, reference_com_vel,
+                reference_com_acc, reference_com_jerk, desired_com,
+                desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+                desired_cop_reference_2d, desired_cop_computed_2d);
 }
 
 void CopStabilizer::stabilizeJerk(
@@ -742,16 +742,16 @@ void CopStabilizer::stabilizeJerk(
 }
 
 double CopStabilizer::distributeForces(
-    const eVector3& desired_cop, const eVector2 LF_xy, const double LF_force_z,
+    const eVector3 &desired_cop, const eVector2 LF_xy, const double LF_force_z,
     const eVector2 LF_torque_xy, const eVector2 RF_xy, const double RF_force_z,
     const eVector2 RF_torque_xy) {
   eVector2 desired_cop_2d = desired_cop.head<2>();
-  return distributeForces(desired_cop_2d, LF_xy, LF_force_z, LF_torque_xy, RF_xy,
-                         RF_force_z, RF_torque_xy);
+  return distributeForces(desired_cop_2d, LF_xy, LF_force_z, LF_torque_xy,
+                          RF_xy, RF_force_z, RF_torque_xy);
 }
 
 double CopStabilizer::distributeForces(
-    const eVector2& desired_cop, const eVector2 LF_xy, const double LF_force_z,
+    const eVector2 &desired_cop, const eVector2 LF_xy, const double LF_force_z,
     const eVector2 LF_torque_xy, const eVector2 RF_xy, const double RF_force_z,
     const eVector2 RF_torque_xy) {
   Eigen::Vector2d cop_L(LF_xy + RotPi_2_ * LF_torque_xy / LF_force_z);
@@ -760,7 +760,7 @@ double CopStabilizer::distributeForces(
   return (desired_cop - cop_R).norm() / (cop_L - cop_R).norm();
 }
 
-std::array<eVector3, 3> CopStabilizer::getStableCoMs(const double& com_height) {
+std::array<eVector3, 3> CopStabilizer::getStableCoMs(const double &com_height) {
   if (settings_.cop_control_type == "p_cc") {
     return {{eVector3(S_coms_.block<1, 2>(0, 0) * actualState2d_x_ +
                           U_coms_(0) * actual_command_.x(),
@@ -801,7 +801,7 @@ std::array<eVector3, 3> CopStabilizer::getStableCoMs(const double& com_height) {
 
 template <typename T, typename vec_T>
 T CopStabilizer::movingAverage(const T x, const unsigned long nb_samples,
-                               vec_T& queue) {
+                               vec_T &queue) {
   if (queue.capacity() < nb_samples) {
     queue.reserve(nb_samples);
   }
@@ -812,18 +812,18 @@ T CopStabilizer::movingAverage(const T x, const unsigned long nb_samples,
     n--;
   }
   T summation = 0 * x;
-  for (T& element : queue) {
+  for (T &element : queue) {
     summation += element;
   }
   return summation / n;
 }
 
 void CopStabilizer::getNonLinearPart(
-    const eVector6& leftFootWrench, const eVector6& rightFootWrench,
-    const Eigen::Vector2d& leftFootPlace, const Eigen::Vector2d& rightFootPlace,
-    const Eigen::Vector2d& CoM, const Eigen::Vector2d& lateral_gravity,
-    const Eigen::Vector2d& externalForce, eVector3& n) {
-  const double& m = settings_.robot_mass;
+    const eVector6 &leftFootWrench, const eVector6 &rightFootWrench,
+    const Eigen::Vector2d &leftFootPlace, const Eigen::Vector2d &rightFootPlace,
+    const Eigen::Vector2d &CoM, const Eigen::Vector2d &lateral_gravity,
+    const Eigen::Vector2d &externalForce, eVector3 &n) {
+  const double &m = settings_.robot_mass;
   Eigen::Vector2d CoM_acc =
       (leftFootWrench.head<2>() + rightFootWrench.head<2>() + externalForce) /
           m +
@@ -835,9 +835,9 @@ void CopStabilizer::getNonLinearPart(
 }
 
 void CopStabilizer::getNonLinearPart(
-    const eVector6& leftFootWrench, const eVector6& rightFootWrench,
-    const Eigen::Vector2d& leftFootPlace, const Eigen::Vector2d& rightFootPlace,
-    const Eigen::Vector2d& CoM, const Eigen::Vector2d& CoM_acc, eVector3& n) {
+    const eVector6 &leftFootWrench, const eVector6 &rightFootWrench,
+    const Eigen::Vector2d &leftFootPlace, const Eigen::Vector2d &rightFootPlace,
+    const Eigen::Vector2d &CoM, const Eigen::Vector2d &CoM_acc, eVector3 &n) {
   /**
    * FeetWrenches are sorted as [force_x, force_y, force_z, torque_x, torque_y,
    * torque_z]
@@ -848,12 +848,12 @@ void CopStabilizer::getNonLinearPart(
                    rightFootPlace_c, CoM_acc, n);
 }
 
-void CopStabilizer::getNonLinearPart(const eVector6& leftFootWrench,
-                                     const eVector6& rightFootWrench,
-                                     const Eigen::Vector2d& leftFootPlace_c,
-                                     const Eigen::Vector2d& rightFootPlace_c,
-                                     const Eigen::Vector2d& CoM_acc,
-                                     eVector3& n) {
+void CopStabilizer::getNonLinearPart(const eVector6 &leftFootWrench,
+                                     const eVector6 &rightFootWrench,
+                                     const Eigen::Vector2d &leftFootPlace_c,
+                                     const Eigen::Vector2d &rightFootPlace_c,
+                                     const Eigen::Vector2d &CoM_acc,
+                                     eVector3 &n) {
   /**
    * FeetWrenches are sorted as [force_x, force_y, force_z, torque_x, torque_y,
    * torque_z] FeetPlaces_c are the feet places measured from the CoM of the
@@ -867,16 +867,16 @@ void CopStabilizer::getNonLinearPart(const eVector6& leftFootWrench,
       0;
 }
 
-void CopStabilizer::getNonLinearPart(const eVector3& com,
-                                     const eVector3& com_acc,
-                                     const eVector2& cop, eVector3& n) {
+void CopStabilizer::getNonLinearPart(const eVector3 &com,
+                                     const eVector3 &com_acc,
+                                     const eVector2 &cop, eVector3 &n) {
   n << cop.head<2>() - (com.head<2>() - (com_acc.head<2>()) / w2_), 0;
 }
 
-void CopStabilizer::getNonLinearPart(eVector3& n) { n.fill(0.0); }
+void CopStabilizer::getNonLinearPart(eVector3 &n) { n.fill(0.0); }
 
-bool CopStabilizer::isPointInPolygon(const eVector2& point,
-                                     const Polygon2D& polygon) {
+bool CopStabilizer::isPointInPolygon(const eVector2 &point,
+                                     const Polygon2D &polygon) {
   wykobi_2d_point_.x = point.x();
   wykobi_2d_point_.y = point.y();
   return wykobi::point_in_convex_polygon(wykobi_2d_point_, polygon);
@@ -903,8 +903,8 @@ CopStabilizer::estimateCopDisturbance(const eVector2 &currentTrackingError,
   return v;
 }
 
-void CopStabilizer::setCOPgains(const eVector3& cop_x_gains,
-                                const eVector3& cop_y_gains) {
+void CopStabilizer::setCOPgains(const eVector3 &cop_x_gains,
+                                const eVector3 &cop_y_gains) {
   settings_.cop_x_gains = cop_x_gains;
   settings_.cop_y_gains = cop_y_gains;
   cx_gainK_ = settings_.cop_x_gains;
@@ -917,7 +917,7 @@ void CopStabilizer::setPCCgains(const double cop_pcc_gains) {
   cy_gainK2_ << settings_.cop_p_cc_gain, settings_.cop_p_cc_gain / w_;
 }
 
-void CopStabilizer::setIntegralGains(const eVector2& integral_gains) {
+void CopStabilizer::setIntegralGains(const eVector2 &integral_gains) {
   settings_.integral_gain = integral_gains;
 }
 

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -2,7 +2,8 @@
 
 #include "biped-stabilizer/third_party/wykobi/wykobi_algorithm.hpp"
 
-namespace biped_stabilizer {
+namespace biped_stabilizer
+{
 
 const double DT_DERIVATIVE = 1e-4;
 
@@ -18,9 +19,10 @@ CopStabilizer::CopStabilizer(const CopStabilizerSettings &settings)
 
 CopStabilizer::~CopStabilizer() {}
 
-void CopStabilizer::configure(const CopStabilizerSettings &settings) {
+void CopStabilizer::configure(const CopStabilizerSettings & settings)
+{
   settings_ = settings;
-  const double &dt = settings_.dt;
+  const double & dt = settings_.dt;
   configured_ = true;
   first_iter_ = true;
   w2_ = settings_.g / settings_.height;
@@ -29,7 +31,7 @@ void CopStabilizer::configure(const CopStabilizerSettings &settings) {
   // These system matrices correspond to "dP->CCP" state: c, c_dot, ccop and
   // input ccop_dot
   A_ << cosh(w_ * dt), sinh(w_ * dt) / w_, 1 - cosh(w_ * dt),
-      w_ * sinh(w_ * dt), cosh(w_ * dt), -w_ * sinh(w_ * dt), 0, 0, 1;
+    w_ * sinh(w_ * dt), cosh(w_ * dt), -w_ * sinh(w_ * dt), 0, 0, 1;
   B_ << dt - sinh(w_ * dt) / w_, 1 - cosh(w_ * dt), dt;
 
   cx_gainK_ = settings_.cop_x_gains;
@@ -48,16 +50,16 @@ void CopStabilizer::configure(const CopStabilizerSettings &settings) {
 
   // values for J_CCC method
   S_coms_j_ << 1, dt - DT_DERIVATIVE, pow(dt - DT_DERIVATIVE, 2) / 2, 1, dt,
-      pow(dt, 2) / 2, 1, dt + DT_DERIVATIVE, pow(dt + DT_DERIVATIVE, 2) / 2;
+    pow(dt, 2) / 2, 1, dt + DT_DERIVATIVE, pow(dt + DT_DERIVATIVE, 2) / 2;
   U_coms_j_ << pow(dt - DT_DERIVATIVE, 3) / 6, pow(dt, 3) / 6,
-      pow(dt + DT_DERIVATIVE, 3) / 6;
+    pow(dt + DT_DERIVATIVE, 3) / 6;
 
   // Values for P_CC method
   S_coms_ << cosh(w_ * (dt - DT_DERIVATIVE)),
-      sinh(w_ * (dt - DT_DERIVATIVE)) / w_, cosh(w_ * dt), sinh(w_ * dt) / w_,
-      cosh(w_ * (dt + DT_DERIVATIVE)), sinh(w_ * (dt + DT_DERIVATIVE)) / w_;
+    sinh(w_ * (dt - DT_DERIVATIVE)) / w_, cosh(w_ * dt), sinh(w_ * dt) / w_,
+    cosh(w_ * (dt + DT_DERIVATIVE)), sinh(w_ * (dt + DT_DERIVATIVE)) / w_;
   U_coms_ << 1 - cosh(w_ * (dt - DT_DERIVATIVE)), 1 - cosh(w_ * dt),
-      1 - cosh(w_ * (dt + DT_DERIVATIVE));
+    1 - cosh(w_ * (dt + DT_DERIVATIVE));
 
   target_com_.setZero();
   target_com_vel_.setZero();
@@ -74,13 +76,13 @@ void CopStabilizer::configure(const CopStabilizerSettings &settings) {
 
   local_foot_description_.resize(4);
   local_foot_description_[0] =
-      eVector3(settings_.foot_length / 2, settings_.foot_width / 2, 0.);
+    eVector3(settings_.foot_length / 2, settings_.foot_width / 2, 0.);
   local_foot_description_[1] =
-      eVector3(settings_.foot_length / 2, -settings_.foot_width / 2, 0.);
+    eVector3(settings_.foot_length / 2, -settings_.foot_width / 2, 0.);
   local_foot_description_[2] =
-      eVector3(-settings_.foot_length / 2, settings_.foot_width / 2, 0.);
+    eVector3(-settings_.foot_length / 2, settings_.foot_width / 2, 0.);
   local_foot_description_[3] =
-      eVector3(-settings_.foot_length / 2, -settings_.foot_width / 2, 0.);
+    eVector3(-settings_.foot_length / 2, -settings_.foot_width / 2, 0.);
   foot_description_.clear();
   foot_description_.reserve(10 * 4);
   wykobi_foot_description_.clear();
@@ -128,8 +130,10 @@ void CopStabilizer::configure(const CopStabilizerSettings &settings) {
   //                   &errorSum_[1], &registered_variables_);
 }
 
-void CopStabilizer::computeSupportPolygon(const eMatrixHoms &stance_poses,
-                                          Polygon2D &convex_hull) {
+void CopStabilizer::computeSupportPolygon(
+  const eMatrixHoms & stance_poses,
+  Polygon2D & convex_hull)
+{
   // Compute the global position of the feet edges.
   foot_description_.clear();
   for (size_t j = 0; j < stance_poses.size(); j++) {
@@ -141,18 +145,19 @@ void CopStabilizer::computeSupportPolygon(const eMatrixHoms &stance_poses,
   wykobi_foot_description_.clear();
   for (size_t i = 0; i < foot_description_.size(); ++i) {
     wykobi_foot_description_.push_back(
-        wykobi::make_point(foot_description_[i](0), foot_description_[i](1)));
+      wykobi::make_point(foot_description_[i](0), foot_description_[i](1)));
   }
   // Compute the convex hull.
   convex_hull.clear();
   wykobi::algorithm::convex_hull_graham_scan<wykobi::point2d<double>>(
-      wykobi_foot_description_.begin(), wykobi_foot_description_.end(),
-      std::back_inserter(convex_hull));
+    wykobi_foot_description_.begin(), wykobi_foot_description_.end(),
+    std::back_inserter(convex_hull));
 }
 
 void CopStabilizer::projectCOPinSupportPolygon(
-    const eVector2 &target_cop_unclamped, const Polygon2D &polygon,
-    eVector2 &target_cop) {
+  const eVector2 & target_cop_unclamped, const Polygon2D & polygon,
+  eVector2 & target_cop)
+{
   wykobi_cop_unclamped_.x = target_cop_unclamped.x();
   wykobi_cop_unclamped_.y = target_cop_unclamped.y();
   if (wykobi::point_in_convex_polygon(wykobi_cop_unclamped_, polygon)) {
@@ -161,7 +166,7 @@ void CopStabilizer::projectCOPinSupportPolygon(
     // ROS_INFO("[com_control_utils] COP_unclamped not in the support polygon
     // !");
     wykobi_cop_clamped_ = wykobi::closest_point_on_polygon_from_point(
-        polygon, wykobi_cop_unclamped_);
+      polygon, wykobi_cop_unclamped_);
     target_cop.x() = wykobi_cop_clamped_.x;
     target_cop.y() = wykobi_cop_clamped_.y;
   }
@@ -214,19 +219,21 @@ void CopStabilizer::stabilize(
                          desired_cop_reference, desired_cop_computed);
   else if (settings_.cop_control_type == "approximated_acceleration")
     return stabilizeApproximateAcceleration(
-        actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
-        reference_com, reference_com_vel, reference_com_acc, desired_com,
-        desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-        desired_cop_reference, desired_cop_computed);
-  else if (settings_.cop_control_type == "j_ccc")
+      actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
+      reference_com, reference_com_vel, reference_com_acc, desired_com,
+      desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+      desired_cop_reference, desired_cop_computed);
+  } else if (settings_.cop_control_type == "j_ccc") {
     return stabilizeJerk(
-        actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
-        reference_com, reference_com_vel, reference_com_acc, reference_com_jerk,
-        desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-        desired_cop_reference, desired_cop_computed);
-  else
-    throw std::runtime_error("Invalid cop control type, got : " +
-                             settings_.cop_control_type);
+      actual_com, actual_com_vel, actual_com_acc, actual_cop, support_polygon,
+      reference_com, reference_com_vel, reference_com_acc, reference_com_jerk,
+      desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+      desired_cop_reference, desired_cop_computed);
+  } else {
+    throw std::runtime_error(
+            "Invalid cop control type, got : " +
+            settings_.cop_control_type);
+  }
 }
 
 void CopStabilizer::stabilizeCOP( // Not supported
@@ -242,10 +249,10 @@ void CopStabilizer::stabilizeCOP( // Not supported
   // ROS_INFO("Call stabilizeCOP");
   if (!configured_) {
     throw std::runtime_error(
-        "Stabilizer not initialized, please call the constructor with "
-        "arguments first");
+            "Stabilizer not initialized, please call the constructor with "
+            "arguments first");
   }
-  const double &dt = settings_.dt;
+  const double & dt = settings_.dt;
 
   target_com_ = reference_com;
   target_com_vel_ = reference_com_vel;
@@ -253,31 +260,31 @@ void CopStabilizer::stabilizeCOP( // Not supported
 
   // REAL values
   const Eigen::Vector3d actualState_x(actual_com.x(), actual_com_vel.x(),
-                                      actual_cop.x());
+    actual_cop.x());
   const Eigen::Vector3d actualState_y(actual_com.y(), actual_com_vel.y(),
-                                      actual_cop.y());
+    actual_cop.y());
 
   // Reference values
   const Eigen::Vector3d reference_com_jerky(
-      (reference_com_acc - old_reference_com_acc_) / dt);
+    (reference_com_acc - old_reference_com_acc_) / dt);
   const Eigen::Vector3d reference_com_jerk(
-      movingAverage(reference_com_jerky, 5, jerk_ma_queue_));
+    movingAverage(reference_com_jerky, 5, jerk_ma_queue_));
   const Eigen::Vector2d referenceCCOP(reference_com.head<2>() -
-                                      reference_com_acc.head<2>() / w2_);
+    reference_com_acc.head<2>() / w2_);
   const Eigen::Vector2d referenceCCOP_vel(reference_com_vel.head<2>() -
-                                          reference_com_jerk.head<2>() / w2_);
+    reference_com_jerk.head<2>() / w2_);
 
   const Eigen::Vector3d referenceState_x(
-      reference_com.x(), reference_com_vel.x(), referenceCCOP.x());
+    reference_com.x(), reference_com_vel.x(), referenceCCOP.x());
   const Eigen::Vector3d referenceState_y(
-      reference_com.y(), reference_com_vel.y(), referenceCCOP.y());
+    reference_com.y(), reference_com_vel.y(), referenceCCOP.y());
 
   // Tracking
   Eigen::Vector3d stateTrackingError_x(actualState_x - referenceState_x);
   Eigen::Vector3d stateTrackingError_y(actualState_y - referenceState_y);
   Eigen::Vector2d feedbackTerm;
   feedbackTerm << cx_gainK_.transpose() * stateTrackingError_x,
-      cy_gainK_.transpose() * stateTrackingError_y;
+    cy_gainK_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM
@@ -293,34 +300,34 @@ void CopStabilizer::stabilizeCOP( // Not supported
   getNonLinearPart(actual_com, actual_com_acc, actual_cop, non_linear_);
   if (settings_.saturate_cop) {
     Eigen::Vector2d COP_unclamped(nextState_x(2) + non_linear_(0),
-                                  nextState_y(2) + non_linear_(1));
+      nextState_y(2) + non_linear_(1));
 
     if (!isPointInPolygon(COP_unclamped, support_polygon)) {
       eVector2 COP_clamped;
       projectCOPinSupportPolygon(COP_unclamped, support_polygon, COP_clamped);
 
       eVector3 nextRefState_x(A_ * referenceState_x +
-                              B_ * referenceCCOP_vel.x());
+        B_ * referenceCCOP_vel.x());
       eVector3 nextRefState_y(A_ * referenceState_y +
-                              B_ * referenceCCOP_vel.y());
+        B_ * referenceCCOP_vel.y());
       eVector2 nextRefCCOP(nextRefState_x(2), nextRefState_y(2));
       eVector2 LA_trErr_0(A_.block<1, 3>(2, 0) * stateTrackingError_x,
-                          A_.block<1, 3>(2, 0) * stateTrackingError_y);
+        A_.block<1, 3>(2, 0) * stateTrackingError_y);
 
       eVector2 r =
-          COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0;
+        COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0;
 
       eVector3 stateTrackingError_clamped_x =
-          cx_gainK_ * r.x() / (cx_gainK_.dot(cx_gainK_) * B_(2));
+        cx_gainK_ * r.x() / (cx_gainK_.dot(cx_gainK_) * B_(2));
       eVector3 stateTrackingError_clamped_y =
-          cy_gainK_ * r.y() / (cy_gainK_.dot(cy_gainK_) * B_(2));
+        cy_gainK_ * r.y() / (cy_gainK_.dot(cy_gainK_) * B_(2));
 
       eVector3 nextStateTrackingError_clamped_x =
-          A_ * stateTrackingError_x +
-          B_ * cx_gainK_.transpose() * stateTrackingError_clamped_x;
+        A_ * stateTrackingError_x +
+        B_ * cx_gainK_.transpose() * stateTrackingError_clamped_x;
       eVector3 nextStateTrackingError_clamped_y =
-          A_ * stateTrackingError_y +
-          B_ * cy_gainK_.transpose() * stateTrackingError_clamped_y;
+        A_ * stateTrackingError_y +
+        B_ * cy_gainK_.transpose() * stateTrackingError_clamped_y;
 
       nextState_x = nextRefState_x + nextStateTrackingError_clamped_x;
       nextState_y = nextRefState_y + nextStateTrackingError_clamped_y;
@@ -330,11 +337,11 @@ void CopStabilizer::stabilizeCOP( // Not supported
   desired_com << nextState_x(0), nextState_y(0), reference_com.z();
   desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
   desired_com_acc << w2_ * (nextState_x(0) - nextState_x(2)),
-      w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
+    w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
   desired_icp << nextState_x(0) + nextState_x(1) / w_,
-      nextState_y(0) + nextState_y(1) / w_, 0.;
+    nextState_y(0) + nextState_y(1) / w_, 0.;
   actual_icp << actualState_x(0) + actualState_x(1) / w_,
-      actualState_y(0) + actualState_y(1) / w_, 0.;
+    actualState_y(0) + actualState_y(1) / w_, 0.;
   desired_cop_reference << referenceState_x(2), referenceState_y(2), 0.;
   desired_cop_computed << nextState_x(2), nextState_y(2), 0.;
 
@@ -355,10 +362,10 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   // ROS_INFO("Call stabilize approx acceleration");
   if (!configured_) {
     throw std::runtime_error(
-        "Stabilizer not initialized, please call the constructor with "
-        "arguments first");
+            "Stabilizer not initialized, please call the constructor with "
+            "arguments first");
   }
-  const double &dt = settings_.dt;
+  const double & dt = settings_.dt;
 
   target_com_ = reference_com;
   target_com_vel_ = reference_com_vel;
@@ -367,30 +374,30 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   // REFERENCE
   static Eigen::Vector3d old_reference_com_acc = reference_com_acc;
   Eigen::Vector3d reference_com_jerky(
-      (reference_com_acc - old_reference_com_acc) / dt);
+    (reference_com_acc - old_reference_com_acc) / dt);
   Eigen::Vector3d reference_com_jerk(
-      movingAverage(reference_com_jerky, 5, jerk_ma_queue_));
+    movingAverage(reference_com_jerky, 5, jerk_ma_queue_));
   Eigen::Vector2d referenceCCOP(reference_com.head<2>() -
-                                reference_com_acc.head<2>() / w2_);
+    reference_com_acc.head<2>() / w2_);
   Eigen::Vector2d referenceCCOP_vel(reference_com_vel.head<2>() -
-                                    reference_com_jerk.head<2>() / w2_);
+    reference_com_jerk.head<2>() / w2_);
   Eigen::Vector3d referenceState_x(reference_com.x(), reference_com_vel.x(),
-                                   referenceCCOP.x());
+    referenceCCOP.x());
   Eigen::Vector3d referenceState_y(reference_com.y(), reference_com_vel.y(),
-                                   referenceCCOP.y());
+    referenceCCOP.y());
 
   // REAL
   Eigen::Vector3d actualState_x(actual_com.x(), actual_com_vel.x(),
-                                actual_cop.x());
+    actual_cop.x());
   Eigen::Vector3d actualState_y(actual_com.y(), actual_com_vel.y(),
-                                actual_cop.y());
+    actual_cop.y());
 
   // TRACKING
   Eigen::Vector3d stateTrackingError_x(actualState_x - referenceState_x);
   Eigen::Vector3d stateTrackingError_y(actualState_y - referenceState_y);
   Eigen::Vector2d feedbackTerm;
   feedbackTerm << cx_gainK_.transpose() * stateTrackingError_x,
-      cy_gainK_.transpose() * stateTrackingError_y;
+    cy_gainK_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM
@@ -402,7 +409,7 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
     errorSum += actual_cop.head<2>() - referenceCCOP;
 
     Eigen::Vector2d integral_signal(
-        (settings_.integral_gain.array() * errorSum.array()).matrix());
+      (settings_.integral_gain.array() * errorSum.array()).matrix());
     feedbackTerm += integral_signal;
   }
   Eigen::Vector2d commandedCCOP_vel(referenceCCOP_vel + feedbackTerm);
@@ -415,7 +422,7 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   if (settings_.saturate_cop) {
     getNonLinearPart(actual_com, actual_com_acc, actual_cop, non_linear_);
     Eigen::Vector2d COP_unclamped(nextState_x(2) + non_linear_(0),
-                                  nextState_y(2) + non_linear_(1));
+      nextState_y(2) + non_linear_(1));
 
     if (!isPointInPolygon(COP_unclamped, support_polygon)) {
       // ROS_INFO("[com_control_utils] COP_unclamped not in the support polygon
@@ -425,16 +432,16 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
       projectCOPinSupportPolygon(COP_unclamped, support_polygon, COP_clamped);
 
       eVector3 nextRefState_x(A_ * referenceState_x +
-                              B_ * referenceCCOP_vel.x());
+        B_ * referenceCCOP_vel.x());
       eVector3 nextRefState_y(A_ * referenceState_y +
-                              B_ * referenceCCOP_vel.y());
+        B_ * referenceCCOP_vel.y());
       eVector2 nextRefCCOP(nextRefState_x(2), nextRefState_y(2));
       eVector2 LA_trErr_0(A_.block<1, 3>(2, 0) * stateTrackingError_x,
-                          A_.block<1, 3>(2, 0) * stateTrackingError_y);
+        A_.block<1, 3>(2, 0) * stateTrackingError_y);
 
       eVector2 saturatedFeedbackTerm =
-          (COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0) /
-          B_(2);
+        (COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0) /
+        B_(2);
       commandedCCOP_vel = referenceCCOP_vel + saturatedFeedbackTerm;
 
       nextState_x = A_ * actualState_x + B_ * commandedCCOP_vel.x();
@@ -445,11 +452,11 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   desired_com << nextState_x(0), nextState_y(0), reference_com.z();
   desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
   desired_com_acc << w2_ * (nextState_x(0) - nextState_x(2)),
-      w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
+    w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
   desired_icp << nextState_x(0) + nextState_x(1) / w_,
-      nextState_y(0) + nextState_y(1) / w_, 0.;
+    nextState_y(0) + nextState_y(1) / w_, 0.;
   actual_icp << actualState_x(0) + actualState_x(1) / w_,
-      actualState_y(0) + actualState_y(1) / w_, 0.;
+    actualState_y(0) + actualState_y(1) / w_, 0.;
   desired_cop_reference << referenceState_x(2), referenceState_y(2), 0.;
   desired_cop_computed << nextState_x(2), nextState_y(2), 0.;
 
@@ -470,8 +477,8 @@ void CopStabilizer::stabilizeP_CC(
   // ROS_INFO("Call stabilizeCCOP");
   if (!configured_) {
     throw std::runtime_error(
-        "Stabilizer not initialized, please call the constructor with "
-        "arguments first");
+            "Stabilizer not initialized, please call the constructor with "
+            "arguments first");
   }
 
   target_com_ = reference_com;
@@ -483,12 +490,12 @@ void CopStabilizer::stabilizeP_CC(
   }
   // REFERENCE
   const Eigen::Vector2d referenceCCOP(reference_com.head<2>() -
-                                      reference_com_acc.head<2>() / w2_);
+    reference_com_acc.head<2>() / w2_);
   target_cop_ = referenceCCOP;
   const Eigen::Vector2d referenceState_x(reference_com.x(),
-                                         reference_com_vel.x());
+    reference_com_vel.x());
   const Eigen::Vector2d referenceState_y(reference_com.y(),
-                                         reference_com_vel.y());
+    reference_com_vel.y());
 
   // REAL
   actualState2d_x_ = eVector2(actual_com.x(), actual_com_vel.x());
@@ -496,18 +503,18 @@ void CopStabilizer::stabilizeP_CC(
 
   // TRACKING
   const Eigen::Vector2d stateTrackingError_x(actualState2d_x_ -
-                                             referenceState_x);
+    referenceState_x);
   const Eigen::Vector2d stateTrackingError_y(actualState2d_y_ -
-                                             referenceState_y);
+    referenceState_y);
 
   estimated_disturbance_[0] = estimateCopDisturbance(
-      stateTrackingError_x, oldTrackingError2_x_, cx_gainK2_);
+    stateTrackingError_x, oldTrackingError2_x_, cx_gainK2_);
   estimated_disturbance_[1] = estimateCopDisturbance(
-      stateTrackingError_y, oldTrackingError2_y_, cy_gainK2_);
+    stateTrackingError_y, oldTrackingError2_y_, cy_gainK2_);
 
   Eigen::Vector2d feedbackTerm;
   feedbackTerm << cx_gainK2_.transpose() * stateTrackingError_x,
-      cy_gainK2_.transpose() * stateTrackingError_y;
+    cy_gainK2_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM (actually not in the DCM, it
@@ -522,7 +529,7 @@ void CopStabilizer::stabilizeP_CC(
     errorSum_ += actual_cop.head<2>() - referenceCCOP;
 
     Eigen::Vector2d integral_signal(
-        (settings_.integral_gain.array() * errorSum_.array()).matrix());
+      (settings_.integral_gain.array() * errorSum_.array()).matrix());
     feedbackTerm += integral_signal;
   }
   actual_command_ = (referenceCCOP + feedbackTerm);
@@ -535,8 +542,9 @@ void CopStabilizer::stabilizeP_CC(
       // ROS_INFO("[com_control_utils] COP_unclamped not in the support polygon
       // !");
       eVector2 COP_clamped;
-      projectCOPinSupportPolygon(desired_uncampled_cop_, support_polygon,
-                                 COP_clamped);
+      projectCOPinSupportPolygon(
+        desired_uncampled_cop_, support_polygon,
+        COP_clamped);
       actual_command_ = COP_clamped - non_linear_.head<2>();
     }
   }
@@ -549,11 +557,11 @@ void CopStabilizer::stabilizeP_CC(
   desired_com << nextState_x(0), nextState_y(0), reference_com.z();
   desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
   desired_com_acc << w2_ * (nextState_x(0) - actual_command_.x()),
-      w2_ * (nextState_y(0) - actual_command_.y()), reference_com_acc.z();
+    w2_ * (nextState_y(0) - actual_command_.y()), reference_com_acc.z();
   desired_icp << nextState_x(0) + nextState_x(1) / w_,
-      nextState_y(0) + nextState_y(1) / w_, 0.;
+    nextState_y(0) + nextState_y(1) / w_, 0.;
   actual_icp << actualState2d_x_(0) + actualState2d_x_(1) / w_,
-      actualState2d_y_(0) + actualState2d_y_(1) / w_, 0.;
+    actualState2d_y_(0) + actualState2d_y_(1) / w_, 0.;
   desired_cop_reference << referenceCCOP + non_linear_.head<2>(), 0.;
   desired_cop_computed << actual_command_ + non_linear_.head<2>(), 0.;
 }
@@ -576,33 +584,33 @@ void CopStabilizer::stabilizeJerk(
 
   // REFERENCE
   const eVector3 referenceState_x(reference_com.x(), reference_com_vel.x(),
-                                  reference_com_acc.x());
+    reference_com_acc.x());
   const eVector3 referenceState_y(reference_com.y(), reference_com_vel.y(),
-                                  reference_com_acc.y());
+    reference_com_acc.y());
   const eVector2 referenceCCOP(reference_com.head<2>() -
-                               reference_com_acc.head<2>() / (w2_));
+    reference_com_acc.head<2>() / (w2_));
   target_cop_ = referenceCCOP;
 
   // REAL
   actualState3d_x_ =
-      eVector3(actual_com.x(), actual_com_vel.x(), actual_com_acc.x());
+    eVector3(actual_com.x(), actual_com_vel.x(), actual_com_acc.x());
   actualState3d_y_ =
-      eVector3(actual_com.y(), actual_com_vel.y(), actual_com_acc.y());
+    eVector3(actual_com.y(), actual_com_vel.y(), actual_com_acc.y());
 
   // TRACKING
   const Eigen::Vector3d stateTrackingError_x(actualState3d_x_ -
-                                             referenceState_x);
+    referenceState_x);
   const Eigen::Vector3d stateTrackingError_y(actualState3d_y_ -
-                                             referenceState_y);
+    referenceState_y);
 
   estimated_disturbance_[0] = estimateJerkDisturbance(
-      stateTrackingError_x, oldTrackingError_x_, cx_gainK_);
+    stateTrackingError_x, oldTrackingError_x_, cx_gainK_);
   estimated_disturbance_[1] = estimateJerkDisturbance(
-      stateTrackingError_y, oldTrackingError_y_, cy_gainK_);
+    stateTrackingError_y, oldTrackingError_y_, cy_gainK_);
 
   Eigen::Vector2d feedbackTerm;
   feedbackTerm << cx_gainK_.transpose() * stateTrackingError_x,
-      cy_gainK_.transpose() * stateTrackingError_y;
+    cy_gainK_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM
@@ -613,42 +621,44 @@ void CopStabilizer::stabilizeJerk(
     errorSum_ += actual_cop.head<2>() - referenceCCOP;
 
     Eigen::Vector2d integral_signal(
-        (settings_.integral_gain.array() * errorSum_.array()).matrix());
+      (settings_.integral_gain.array() * errorSum_.array()).matrix());
     feedbackTerm += integral_signal;
   }
   actual_command_ = eVector2(reference_com_jerk.head<2>() + feedbackTerm);
   Eigen::Vector3d nextState_x(Aj_ * actualState3d_x_ +
-                              Bj_ * actual_command_.x());
+    Bj_ * actual_command_.x());
   Eigen::Vector3d nextState_y(Aj_ * actualState3d_y_ +
-                              Bj_ * actual_command_.y());
+    Bj_ * actual_command_.y());
 
   getNonLinearPart(actual_com, actual_com_acc, actual_cop, non_linear_);
   desired_uncampled_cop_ =
-      eVector2(nextState_x(0) - nextState_x(2) / w2_ + non_linear_(0),
-               nextState_y(0) - nextState_y(2) / w2_ + non_linear_(1));
+    eVector2(
+    nextState_x(0) - nextState_x(2) / w2_ + non_linear_(0),
+    nextState_y(0) - nextState_y(2) / w2_ + non_linear_(1));
   if (settings_.saturate_cop) {
     if (!isPointInPolygon(desired_uncampled_cop_, support_polygon)) {
       // ROS_INFO("[com_control_utils] COP_unclamped not in the support polygon
       // !");
 
       eVector2 COP_clamped;
-      projectCOPinSupportPolygon(desired_uncampled_cop_, support_polygon,
-                                 COP_clamped);
+      projectCOPinSupportPolygon(
+        desired_uncampled_cop_, support_polygon,
+        COP_clamped);
 
       const eVector3 nextRefState_x(Aj_ * referenceState_x +
-                                    Bj_ * reference_com_jerk.x());
+        Bj_ * reference_com_jerk.x());
       const eVector3 nextRefState_y(Aj_ * referenceState_y +
-                                    Bj_ * reference_com_jerk.y());
+        Bj_ * reference_com_jerk.y());
       const eVector2 nextRefCCOP(nextRefState_x(0) - nextRefState_x(2) / w2_,
-                                 nextRefState_y(0) - nextRefState_y(2) / w2_);
+        nextRefState_y(0) - nextRefState_y(2) / w2_);
       eVector3 L;
       L << 1, 0, -1 / w2_;
       const eVector2 LA_trErr_0(L.transpose() * Aj_ * stateTrackingError_x,
-                                L.transpose() * Aj_ * stateTrackingError_y);
+        L.transpose() * Aj_ * stateTrackingError_y);
 
       const eVector2 saturatedFeedbackTerm =
-          (COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0) /
-          (L.transpose() * Bj_);
+        (COP_clamped - nextRefCCOP - non_linear_.head<2>() - LA_trErr_0) /
+        (L.transpose() * Bj_);
       actual_command_ = reference_com_jerk.head<2>() + saturatedFeedbackTerm;
 
       nextState_x = Aj_ * actualState3d_x_ + Bj_ * actual_command_.x();
@@ -660,68 +670,78 @@ void CopStabilizer::stabilizeJerk(
   desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
   desired_com_acc << nextState_x(2), nextState_y(2), reference_com_acc.z();
   desired_icp << nextState_x(0) + nextState_x(1) / w_,
-      nextState_y(0) + nextState_y(1) / w_, 0.;
+    nextState_y(0) + nextState_y(1) / w_, 0.;
   actual_icp << actualState3d_x_(0) + actualState3d_x_(1) / w_,
-      actualState3d_y_(0) + actualState3d_y_(1) / w_, 0.;
+    actualState3d_y_(0) + actualState3d_y_(1) / w_, 0.;
   desired_cop_reference << referenceCCOP.x() + non_linear_.x(),
-      referenceCCOP.y() + non_linear_.y(), 0.;
+    referenceCCOP.y() + non_linear_.y(), 0.;
   desired_cop_computed << nextState_x(0) - nextState_x(2) / w2_ +
-                              non_linear_.x(),
-      nextState_y(0) - nextState_y(2) / w2_ + non_linear_.y(), 0.;
+    non_linear_.x(),
+    nextState_y(0) - nextState_y(2) / w2_ + non_linear_.y(), 0.;
 }
 
 double CopStabilizer::distributeForces(
-    const eVector2 &desired_cop, const eVector2 LF_xy, const double LF_force_z,
-    const eVector2 LF_torque_xy, const eVector2 RF_xy, const double RF_force_z,
-    const eVector2 RF_torque_xy) {
+  const eVector2 & desired_cop, const eVector2 LF_xy, const double LF_force_z,
+  const eVector2 LF_torque_xy, const eVector2 RF_xy, const double RF_force_z,
+  const eVector2 RF_torque_xy)
+{
   Eigen::Vector2d cop_L(LF_xy + RotPi_2_ * LF_torque_xy / LF_force_z);
   Eigen::Vector2d cop_R(RF_xy + RotPi_2_ * RF_torque_xy / RF_force_z);
 
   return (desired_cop - cop_R).norm() / (cop_L - cop_R).norm();
 }
 
-std::array<eVector3, 3> CopStabilizer::getStableCoMs(const double &com_height) {
+std::array<eVector3, 3> CopStabilizer::getStableCoMs(const double & com_height)
+{
   if (settings_.cop_control_type == "p_cc") {
-    return {{eVector3(S_coms_.block<1, 2>(0, 0) * actualState2d_x_ +
-                          U_coms_(0) * actual_command_.x(),
-                      S_coms_.block<1, 2>(0, 0) * actualState2d_y_ +
-                          U_coms_(0) * actual_command_.y(),
-                      com_height),
-             eVector3(S_coms_.block<1, 2>(1, 0) * actualState2d_x_ +
-                          U_coms_(1) * actual_command_.x(),
-                      S_coms_.block<1, 2>(1, 0) * actualState2d_y_ +
-                          U_coms_(1) * actual_command_.y(),
-                      com_height),
-             eVector3(S_coms_.block<1, 2>(2, 0) * actualState2d_x_ +
-                          U_coms_(2) * actual_command_.x(),
-                      S_coms_.block<1, 2>(2, 0) * actualState2d_y_ +
-                          U_coms_(2) * actual_command_.y(),
-                      com_height)}};
+    return {{eVector3(
+        S_coms_.block<1, 2>(0, 0) * actualState2d_x_ +
+        U_coms_(0) * actual_command_.x(),
+        S_coms_.block<1, 2>(0, 0) * actualState2d_y_ +
+        U_coms_(0) * actual_command_.y(),
+        com_height),
+      eVector3(
+        S_coms_.block<1, 2>(1, 0) * actualState2d_x_ +
+        U_coms_(1) * actual_command_.x(),
+        S_coms_.block<1, 2>(1, 0) * actualState2d_y_ +
+        U_coms_(1) * actual_command_.y(),
+        com_height),
+      eVector3(
+        S_coms_.block<1, 2>(2, 0) * actualState2d_x_ +
+        U_coms_(2) * actual_command_.x(),
+        S_coms_.block<1, 2>(2, 0) * actualState2d_y_ +
+        U_coms_(2) * actual_command_.y(),
+        com_height)}};
   } else if (settings_.cop_control_type == "j_ccc") {
-    return {{eVector3(S_coms_j_.block<1, 3>(0, 0) * actualState3d_x_ +
-                          U_coms_j_(0) * actual_command_.x(),
-                      S_coms_j_.block<1, 3>(0, 0) * actualState3d_y_ +
-                          U_coms_j_(0) * actual_command_.y(),
-                      com_height),
-             eVector3(S_coms_j_.block<1, 3>(1, 0) * actualState3d_x_ +
-                          U_coms_j_(1) * actual_command_.x(),
-                      S_coms_j_.block<1, 3>(1, 0) * actualState3d_y_ +
-                          U_coms_j_(1) * actual_command_.y(),
-                      com_height),
-             eVector3(S_coms_j_.block<1, 3>(2, 0) * actualState3d_x_ +
-                          U_coms_j_(2) * actual_command_.x(),
-                      S_coms_j_.block<1, 3>(2, 0) * actualState3d_y_ +
-                          U_coms_j_(2) * actual_command_.y(),
-                      com_height)}};
+    return {{eVector3(
+        S_coms_j_.block<1, 3>(0, 0) * actualState3d_x_ +
+        U_coms_j_(0) * actual_command_.x(),
+        S_coms_j_.block<1, 3>(0, 0) * actualState3d_y_ +
+        U_coms_j_(0) * actual_command_.y(),
+        com_height),
+      eVector3(
+        S_coms_j_.block<1, 3>(1, 0) * actualState3d_x_ +
+        U_coms_j_(1) * actual_command_.x(),
+        S_coms_j_.block<1, 3>(1, 0) * actualState3d_y_ +
+        U_coms_j_(1) * actual_command_.y(),
+        com_height),
+      eVector3(
+        S_coms_j_.block<1, 3>(2, 0) * actualState3d_x_ +
+        U_coms_j_(2) * actual_command_.x(),
+        S_coms_j_.block<1, 3>(2, 0) * actualState3d_y_ +
+        U_coms_j_(2) * actual_command_.y(),
+        com_height)}};
   } else {
     throw std::runtime_error(
-        "Invalid control type in CopStabilizer::getStableCoMs");
+            "Invalid control type in CopStabilizer::getStableCoMs");
   }
 }
 
-template <typename T, typename vec_T>
-T CopStabilizer::movingAverage(const T x, const unsigned long nb_samples,
-                               vec_T &queue) {
+template<typename T, typename vec_T>
+T CopStabilizer::movingAverage(
+  const T x, const unsigned long nb_samples,
+  vec_T & queue)
+{
   if (queue.capacity() < nb_samples) {
     queue.reserve(nb_samples);
   }
@@ -732,71 +752,81 @@ T CopStabilizer::movingAverage(const T x, const unsigned long nb_samples,
     n--;
   }
   T summation = 0 * x;
-  for (T &element : queue) {
+  for (T & element : queue) {
     summation += element;
   }
   return summation / n;
 }
 
 void CopStabilizer::getNonLinearPart(
-    const eVector6 &leftFootWrench, const eVector6 &rightFootWrench,
-    const Eigen::Vector2d &leftFootPlace, const Eigen::Vector2d &rightFootPlace,
-    const Eigen::Vector2d &CoM, const Eigen::Vector2d &lateral_gravity,
-    const Eigen::Vector2d &externalForce, eVector3 &n) {
-  const double &m = settings_.robot_mass;
+  const eVector6 & leftFootWrench, const eVector6 & rightFootWrench,
+  const Eigen::Vector2d & leftFootPlace, const Eigen::Vector2d & rightFootPlace,
+  const Eigen::Vector2d & CoM, const Eigen::Vector2d & lateral_gravity,
+  const Eigen::Vector2d & externalForce, eVector3 & n)
+{
+  const double & m = settings_.robot_mass;
   Eigen::Vector2d CoM_acc =
-      (leftFootWrench.head<2>() + rightFootWrench.head<2>() + externalForce) /
-          m +
-      lateral_gravity;
+    (leftFootWrench.head<2>() + rightFootWrench.head<2>() + externalForce) /
+    m +
+    lateral_gravity;
   Eigen::Vector2d leftFootPlace_c = leftFootPlace - CoM;
   Eigen::Vector2d rightFootPlace_c = rightFootPlace - CoM;
-  getNonLinearPart(leftFootWrench, rightFootWrench, leftFootPlace_c,
-                   rightFootPlace_c, CoM_acc, n);
+  getNonLinearPart(
+    leftFootWrench, rightFootWrench, leftFootPlace_c,
+    rightFootPlace_c, CoM_acc, n);
 }
 
 void CopStabilizer::getNonLinearPart(
-    const eVector6 &leftFootWrench, const eVector6 &rightFootWrench,
-    const Eigen::Vector2d &leftFootPlace, const Eigen::Vector2d &rightFootPlace,
-    const Eigen::Vector2d &CoM, const Eigen::Vector2d &CoM_acc, eVector3 &n) {
+  const eVector6 & leftFootWrench, const eVector6 & rightFootWrench,
+  const Eigen::Vector2d & leftFootPlace, const Eigen::Vector2d & rightFootPlace,
+  const Eigen::Vector2d & CoM, const Eigen::Vector2d & CoM_acc, eVector3 & n)
+{
   /**
    * FeetWrenches are sorted as [force_x, force_y, force_z, torque_x, torque_y,
    * torque_z]
    */
   Eigen::Vector2d leftFootPlace_c = leftFootPlace - CoM;
   Eigen::Vector2d rightFootPlace_c = rightFootPlace - CoM;
-  getNonLinearPart(leftFootWrench, rightFootWrench, leftFootPlace_c,
-                   rightFootPlace_c, CoM_acc, n);
+  getNonLinearPart(
+    leftFootWrench, rightFootWrench, leftFootPlace_c,
+    rightFootPlace_c, CoM_acc, n);
 }
 
-void CopStabilizer::getNonLinearPart(const eVector6 &leftFootWrench,
-                                     const eVector6 &rightFootWrench,
-                                     const Eigen::Vector2d &leftFootPlace_c,
-                                     const Eigen::Vector2d &rightFootPlace_c,
-                                     const Eigen::Vector2d &CoM_acc,
-                                     eVector3 &n) {
+void CopStabilizer::getNonLinearPart(
+  const eVector6 & leftFootWrench,
+  const eVector6 & rightFootWrench,
+  const Eigen::Vector2d & leftFootPlace_c,
+  const Eigen::Vector2d & rightFootPlace_c,
+  const Eigen::Vector2d & CoM_acc,
+  eVector3 & n)
+{
   /**
    * FeetWrenches are sorted as [force_x, force_y, force_z, torque_x, torque_y,
    * torque_z] FeetPlaces_c are the feet places measured from the CoM of the
    * robot.
    */
   n << (CoM_acc) / w2_ + (leftFootWrench.block<2, 1>(3, 0) +
-                          rightFootWrench.block<2, 1>(3, 0) +
-                          leftFootPlace_c * leftFootWrench(2) +
-                          rightFootPlace_c * rightFootWrench(2)) /
-                             (leftFootWrench(2) + rightFootWrench(2)),
-      0;
+  rightFootWrench.block<2, 1>(3, 0) +
+  leftFootPlace_c * leftFootWrench(2) +
+  rightFootPlace_c * rightFootWrench(2)) /
+    (leftFootWrench(2) + rightFootWrench(2)),
+    0;
 }
 
-void CopStabilizer::getNonLinearPart(const eVector3 &com,
-                                     const eVector3 &com_acc,
-                                     const eVector3 &cop, eVector3 &n) {
+void CopStabilizer::getNonLinearPart(
+  const eVector3 & com,
+  const eVector3 & com_acc,
+  const eVector2 & cop, eVector3 & n)
+{
   n << cop.head<2>() - (com.head<2>() - (com_acc.head<2>()) / w2_), 0;
 }
 
-void CopStabilizer::getNonLinearPart(eVector3 &n) { n.fill(0.0); }
+void CopStabilizer::getNonLinearPart(eVector3 & n) {n.fill(0.0);}
 
-bool CopStabilizer::isPointInPolygon(const eVector2 &point,
-                                     const Polygon2D &polygon) {
+bool CopStabilizer::isPointInPolygon(
+  const eVector2 & point,
+  const Polygon2D & polygon)
+{
   wykobi_2d_point_.x = point.x();
   wykobi_2d_point_.y = point.y();
   return wykobi::point_in_convex_polygon(wykobi_2d_point_, polygon);
@@ -807,7 +837,7 @@ CopStabilizer::estimateJerkDisturbance(const eVector3 &currentTrackingError,
                                        eVector3 &oldTrackingError,
                                        const eVector3 &c_gainK) {
   eVector3 B_ej(currentTrackingError -
-                (A_ + B_ * c_gainK.transpose()) * oldTrackingError);
+    (A_ + B_ * c_gainK.transpose()) * oldTrackingError);
   oldTrackingError = currentTrackingError;
   return ((B_.transpose() * B_ej) / (B_.transpose() * B_))(0);
 }
@@ -817,27 +847,31 @@ CopStabilizer::estimateCopDisturbance(const eVector2 &currentTrackingError,
                                       eVector2 &oldTrackingError,
                                       const eVector2 &c_gainK) {
   eVector2 B_ej(currentTrackingError -
-                (A22_ + B2_ * c_gainK.transpose()) * oldTrackingError);
+    (A22_ + B2_ * c_gainK.transpose()) * oldTrackingError);
   double v = ((B2_.transpose() * B_ej) / (B2_.transpose() * B2_))(0);
   oldTrackingError = currentTrackingError;
   return v;
 }
 
-void CopStabilizer::setCOPgains(const eVector3 &cop_x_gains,
-                                eVector3 &cop_y_gains) {
+void CopStabilizer::setCOPgains(
+  const eVector3 & cop_x_gains,
+  const eVector3 & cop_y_gains)
+{
   settings_.cop_x_gains = cop_x_gains;
   settings_.cop_y_gains = cop_y_gains;
   cx_gainK_ = settings_.cop_x_gains;
   cy_gainK_ = settings_.cop_y_gains;
 }
 
-void CopStabilizer::setPCCgains(const double cop_pcc_gains) {
+void CopStabilizer::setPCCgains(const double cop_pcc_gains)
+{
   settings_.cop_p_cc_gain = cop_pcc_gains;
   cx_gainK2_ << settings_.cop_p_cc_gain, settings_.cop_p_cc_gain / w_;
   cy_gainK2_ << settings_.cop_p_cc_gain, settings_.cop_p_cc_gain / w_;
 }
 
-void CopStabilizer::setIntegralGains(const eVector2 &integral_gains) {
+void CopStabilizer::setIntegralGains(const eVector2 & integral_gains)
+{
   settings_.integral_gain = integral_gains;
 }
 

--- a/src/cop_stabilizer.cpp
+++ b/src/cop_stabilizer.cpp
@@ -144,6 +144,10 @@ void CopStabilizer::stabilize(
             reference_com_acc, reference_com_jerk, desired_com, desired_com_vel,
             desired_com_acc, desired_icp, actual_icp, desired_cop_reference_2d,
             desired_cop_computed_2d);
+  desired_cop_reference.head<2>() = desired_cop_reference_2d;
+  desired_cop_reference.z() = 0.0;
+  desired_cop_computed.head<2>() = desired_cop_reference_2d;
+  desired_cop_computed.z() = 0.0;
 }
 
 void CopStabilizer::stabilize(
@@ -161,11 +165,11 @@ void CopStabilizer::stabilize(
   if (settings_.saturate_cop) {
     computeSupportPolygon(actual_stance_poses, support_polygon);
   } // else skip computation to save computation time
-  return stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop,
-                   support_polygon, reference_com, reference_com_vel,
-                   reference_com_acc, reference_com_jerk, desired_com,
-                   desired_com_vel, desired_com_acc, desired_icp, actual_icp,
-                   desired_cop_reference, desired_cop_computed);
+  stabilize(actual_com, actual_com_vel, actual_com_acc, actual_cop,
+            support_polygon, reference_com, reference_com_vel,
+            reference_com_acc, reference_com_jerk, desired_com,
+            desired_com_vel, desired_com_acc, desired_icp, actual_icp,
+            desired_cop_reference, desired_cop_computed);
 }
 
 void CopStabilizer::stabilize(
@@ -187,6 +191,10 @@ void CopStabilizer::stabilize(
             reference_com_acc, reference_com_jerk, desired_com, desired_com_vel,
             desired_com_acc, desired_icp, actual_icp, desired_cop_reference_2d,
             desired_cop_computed_2d);
+  desired_cop_reference.head<2>() = desired_cop_reference_2d;
+  desired_cop_reference.z() = 0.0;
+  desired_cop_computed.head<2>() = desired_cop_reference_2d;
+  desired_cop_computed.z() = 0.0;
 }
 
 void CopStabilizer::stabilize(
@@ -248,6 +256,10 @@ void CopStabilizer::stabilizeCOP( // Not supported
                reference_com_acc, desired_com, desired_com_vel, desired_com_acc,
                desired_icp, actual_icp, desired_cop_reference_2d,
                desired_cop_computed_2d);
+  desired_cop_reference.head<2>() = desired_cop_reference_2d;
+  desired_cop_reference.z() = 0.0;
+  desired_cop_computed.head<2>() = desired_cop_reference_2d;
+  desired_cop_computed.z() = 0.0;
 }
 
 void CopStabilizer::stabilizeCOP( // Not supported
@@ -296,8 +308,8 @@ void CopStabilizer::stabilizeCOP( // Not supported
   Eigen::Vector3d stateTrackingError_x(actualState_x - referenceState_x);
   Eigen::Vector3d stateTrackingError_y(actualState_y - referenceState_y);
   Eigen::Vector2d feedbackTerm;
-  feedbackTerm << cx_gainK_.transpose() * stateTrackingError_x,
-      cy_gainK_.transpose() * stateTrackingError_y;
+  feedbackTerm.x() = cx_gainK_.transpose() * stateTrackingError_x;
+  feedbackTerm.y() = cy_gainK_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM
@@ -347,16 +359,22 @@ void CopStabilizer::stabilizeCOP( // Not supported
     }
   }
 
-  desired_com << nextState_x(0), nextState_y(0), reference_com.z();
-  desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
-  desired_com_acc << w2_ * (nextState_x(0) - nextState_x(2)),
-      w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
-  desired_icp << nextState_x(0) + nextState_x(1) / w_,
-      nextState_y(0) + nextState_y(1) / w_, 0.;
-  actual_icp << actualState_x(0) + actualState_x(1) / w_,
-      actualState_y(0) + actualState_y(1) / w_, 0.;
-  desired_cop_reference << referenceState_x(2), referenceState_y(2), 0.;
-  desired_cop_computed << nextState_x(2), nextState_y(2), 0.;
+  desired_com = eVector3(nextState_x(0), nextState_y(0), reference_com.z());
+  desired_com_vel = eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
+  desired_com_acc = eVector3(
+    w2_ * (nextState_x(0) - nextState_x(2)),
+    w2_ * (nextState_y(0) - nextState_y(2)),
+    reference_com_acc.z());
+  desired_icp = eVector3(
+    nextState_x(0) + nextState_x(1) / w_,
+    nextState_y(0) + nextState_y(1) / w_,
+    0.);
+  actual_icp = eVector3(
+    actualState_x(0) + actualState_x(1) / w_,
+    actualState_y(0) + actualState_y(1) / w_,
+    0.);
+  desired_cop_reference = eVector2(referenceState_x(2), referenceState_y(2));
+  desired_cop_computed = eVector2(nextState_x(2), nextState_y(2));
 
   // updating old_acc
   old_reference_com_acc_ = reference_com_acc;
@@ -380,6 +398,10 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
       support_polygon, reference_com, reference_com_vel, reference_com_acc,
       desired_com, desired_com_vel, desired_com_acc, desired_icp, actual_icp,
       desired_cop_reference_2d, desired_cop_computed_2d);
+  desired_cop_reference.head<2>() = desired_cop_reference_2d;
+  desired_cop_reference.z() = 0.0;
+  desired_cop_computed.head<2>() = desired_cop_reference_2d;
+  desired_cop_computed.z() = 0.0;
 }
 
 void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
@@ -428,8 +450,8 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
   Eigen::Vector3d stateTrackingError_x(actualState_x - referenceState_x);
   Eigen::Vector3d stateTrackingError_y(actualState_y - referenceState_y);
   Eigen::Vector2d feedbackTerm;
-  feedbackTerm << cx_gainK_.transpose() * stateTrackingError_x,
-      cy_gainK_.transpose() * stateTrackingError_y;
+  feedbackTerm.x() = cx_gainK_.transpose() * stateTrackingError_x;
+  feedbackTerm.y() = cy_gainK_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM
@@ -478,16 +500,22 @@ void CopStabilizer::stabilizeApproximateAcceleration( // Not supported
     }
   }
 
-  desired_com << nextState_x(0), nextState_y(0), reference_com.z();
-  desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
-  desired_com_acc << w2_ * (nextState_x(0) - nextState_x(2)),
-      w2_ * (nextState_y(0) - nextState_y(2)), reference_com_acc.z();
-  desired_icp << nextState_x(0) + nextState_x(1) / w_,
-      nextState_y(0) + nextState_y(1) / w_, 0.;
-  actual_icp << actualState_x(0) + actualState_x(1) / w_,
-      actualState_y(0) + actualState_y(1) / w_, 0.;
-  desired_cop_reference << referenceState_x(2), referenceState_y(2), 0.;
-  desired_cop_computed << nextState_x(2), nextState_y(2), 0.;
+  desired_com = eVector3(nextState_x(0), nextState_y(0), reference_com.z());
+  desired_com_vel = eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
+  desired_com_acc = eVector3(
+    w2_ * (nextState_x(0) - nextState_x(2)),
+    w2_ * (nextState_y(0) - nextState_y(2)),
+    reference_com_acc.z());
+  desired_icp = eVector3(
+    nextState_x(0) + nextState_x(1) / w_,
+    nextState_y(0) + nextState_y(1) / w_,
+    0.);
+  actual_icp = eVector3(
+    actualState_x(0) + actualState_x(1) / w_,
+    actualState_y(0) + actualState_y(1) / w_,
+    0.);
+  desired_cop_reference = eVector2(referenceState_x(2), referenceState_y(2));
+  desired_cop_computed = eVector2(nextState_x(2), nextState_y(2));
 
   // updating old_acc
   old_reference_com_acc = reference_com_acc;
@@ -511,6 +539,10 @@ void CopStabilizer::stabilizeP_CC(
                 reference_com_acc, desired_com, desired_com_vel,
                 desired_com_acc, desired_icp, actual_icp,
                 desired_cop_reference_2d, desired_cop_computed_2d);
+  desired_cop_reference.head<2>() = desired_cop_reference_2d;
+  desired_cop_reference.z() = 0.0;
+  desired_cop_computed.head<2>() = desired_cop_reference_2d;
+  desired_cop_computed.z() = 0.0;
 }
 
 void CopStabilizer::stabilizeP_CC(
@@ -561,8 +593,8 @@ void CopStabilizer::stabilizeP_CC(
       stateTrackingError_y, oldTrackingError2_y_, cy_gainK2_);
 
   Eigen::Vector2d feedbackTerm;
-  feedbackTerm << cx_gainK2_.transpose() * stateTrackingError_x,
-      cy_gainK2_.transpose() * stateTrackingError_y;
+  feedbackTerm.x() = cx_gainK2_.transpose() * stateTrackingError_x;
+  feedbackTerm.y() = cy_gainK2_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM (actually not in the DCM, it
@@ -599,16 +631,22 @@ void CopStabilizer::stabilizeP_CC(
   nextState_x = A22_ * actualState2d_x_ + B2_ * actual_command_.x();
   nextState_y = A22_ * actualState2d_y_ + B2_ * actual_command_.y();
 
-  desired_com << nextState_x(0), nextState_y(0), reference_com.z();
-  desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
-  desired_com_acc << w2_ * (nextState_x(0) - actual_command_.x()),
-      w2_ * (nextState_y(0) - actual_command_.y()), reference_com_acc.z();
-  desired_icp << nextState_x(0) + nextState_x(1) / w_,
-      nextState_y(0) + nextState_y(1) / w_, 0.;
-  actual_icp << actualState2d_x_(0) + actualState2d_x_(1) / w_,
-      actualState2d_y_(0) + actualState2d_y_(1) / w_, 0.;
-  desired_cop_reference << referenceCCOP + non_linear_.head<2>(), 0.;
-  desired_cop_computed << actual_command_ + non_linear_.head<2>(), 0.;
+  desired_com = eVector3(nextState_x(0), nextState_y(0), reference_com.z());
+  desired_com_vel = eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
+  desired_com_acc = eVector3(
+    w2_ * (nextState_x(0) - actual_command_.x()),
+    w2_ * (nextState_y(0) - actual_command_.y()),
+    reference_com_acc.z());
+  desired_icp = eVector3(
+    nextState_x(0) + nextState_x(1) / w_,
+    nextState_y(0) + nextState_y(1) / w_,
+    0.);
+  actual_icp = eVector3(
+    actualState2d_x_(0) + actualState2d_x_(1) / w_,
+    actualState2d_y_(0) + actualState2d_y_(1) / w_,
+    0.);
+  desired_cop_reference = referenceCCOP + non_linear_.head<2>();
+  desired_cop_computed = actual_command_ + non_linear_.head<2>();
 }
 
 void CopStabilizer::stabilizeJerk(
@@ -630,6 +668,10 @@ void CopStabilizer::stabilizeJerk(
                 reference_com_acc, reference_com_jerk, desired_com,
                 desired_com_vel, desired_com_acc, desired_icp, actual_icp,
                 desired_cop_reference_2d, desired_cop_computed_2d);
+  desired_cop_reference.head<2>() = desired_cop_reference_2d;
+  desired_cop_reference.z() = 0.0;
+  desired_cop_computed.head<2>() = desired_cop_reference_2d;
+  desired_cop_computed.z() = 0.0;
 }
 
 void CopStabilizer::stabilizeJerk(
@@ -675,8 +717,8 @@ void CopStabilizer::stabilizeJerk(
       stateTrackingError_y, oldTrackingError_y_, cy_gainK_);
 
   Eigen::Vector2d feedbackTerm;
-  feedbackTerm << cx_gainK_.transpose() * stateTrackingError_x,
-      cy_gainK_.transpose() * stateTrackingError_y;
+  feedbackTerm.x() = cx_gainK_.transpose() * stateTrackingError_x;
+  feedbackTerm.y() = cy_gainK_.transpose() * stateTrackingError_y;
 
   if (settings_.use_rate_limited_dcm) {
     /// @todo create a low pass filter on the DCM
@@ -712,8 +754,8 @@ void CopStabilizer::stabilizeJerk(
                                     Bj_ * reference_com_jerk.y());
       const eVector2 nextRefCCOP(nextRefState_x(0) - nextRefState_x(2) / w2_,
                                  nextRefState_y(0) - nextRefState_y(2) / w2_);
-      eVector3 L;
-      L << 1, 0, -1 / w2_;
+      eVector3 L (1, 0, -1 / w2_);
+
       const eVector2 LA_trErr_0(L.transpose() * Aj_ * stateTrackingError_x,
                                 L.transpose() * Aj_ * stateTrackingError_y);
 
@@ -727,18 +769,23 @@ void CopStabilizer::stabilizeJerk(
     }
   }
 
-  desired_com << nextState_x(0), nextState_y(0), reference_com.z();
-  desired_com_vel << nextState_x(1), nextState_y(1), reference_com_vel.z();
-  desired_com_acc << nextState_x(2), nextState_y(2), reference_com_acc.z();
-  desired_icp << nextState_x(0) + nextState_x(1) / w_,
-      nextState_y(0) + nextState_y(1) / w_, 0.;
-  actual_icp << actualState3d_x_(0) + actualState3d_x_(1) / w_,
-      actualState3d_y_(0) + actualState3d_y_(1) / w_, 0.;
-  desired_cop_reference << referenceCCOP.x() + non_linear_.x(),
-      referenceCCOP.y() + non_linear_.y(), 0.;
-  desired_cop_computed << nextState_x(0) - nextState_x(2) / w2_ +
-                              non_linear_.x(),
-      nextState_y(0) - nextState_y(2) / w2_ + non_linear_.y(), 0.;
+  desired_com = eVector3(nextState_x(0), nextState_y(0), reference_com.z());
+  desired_com_vel = eVector3(nextState_x(1), nextState_y(1), reference_com_vel.z());
+  desired_com_acc = eVector3(nextState_x(2), nextState_y(2), reference_com_acc.z());
+  desired_icp = eVector3(
+    nextState_x(0) + nextState_x(1) / w_,
+    nextState_y(0) + nextState_y(1) / w_,
+    0.);
+  actual_icp = eVector3(
+    actualState3d_x_(0) + actualState3d_x_(1) / w_,
+    actualState3d_y_(0) + actualState3d_y_(1) / w_,
+    0.);
+  desired_cop_reference = eVector2(
+    referenceCCOP.x() + non_linear_.x(),
+    referenceCCOP.y() + non_linear_.y());
+  desired_cop_computed = eVector2(
+    nextState_x(0) - nextState_x(2) / w2_ + non_linear_.x(),
+    nextState_y(0) - nextState_y(2) / w2_ + non_linear_.y());
 }
 
 double CopStabilizer::distributeForces(
@@ -756,7 +803,6 @@ double CopStabilizer::distributeForces(
     const eVector2 RF_torque_xy) {
   Eigen::Vector2d cop_L(LF_xy + RotPi_2_ * LF_torque_xy / LF_force_z);
   Eigen::Vector2d cop_R(RF_xy + RotPi_2_ * RF_torque_xy / RF_force_z);
-
   return (desired_cop - cop_R).norm() / (cop_L - cop_R).norm();
 }
 

--- a/tests/python/test_cop_stabilizer.py
+++ b/tests/python/test_cop_stabilizer.py
@@ -18,6 +18,8 @@ unittest.util._MAX_LENGTH = 2000
 
 class TestCopStabilizer(unittest.TestCase):
     def setUp(self):
+        self.printing = True
+
         # Create default settings
         settings = bs.CopStabilizerSettings()
         settings.height = 0.87  # [m]
@@ -80,9 +82,10 @@ class TestCopStabilizer(unittest.TestCase):
         error = [0.02, 0.02]
         self.arguments["actual_com"][:2] = error
         self.arguments["actual_cop"][:2] = error
-        desired = stab_loop(self.stab, self.arguments, 1)
+        desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
-        self.assertTrue((desired["com"][:2] < error).all())
+        self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all(),
+                        f"cop: {desired['cop'][:2]}, com: {desired['com'][:2]}")
         self.assertTrue(
             (desired["cop"][:2] == self.settings.cop_p_cc_gain * np.array(error)).all()
         )
@@ -90,7 +93,7 @@ class TestCopStabilizer(unittest.TestCase):
         n = desired["n"]
         self.assertTrue((np.abs(n) == 0).all())
 
-        desired_1000 = stab_loop(self.stab, self.arguments, 1000)
+        desired_1000 = stab_loop(self.stab, self.arguments, 1000, self.printing)
 
         self.assertTrue(
             (desired_1000["com"][:2] + desired_1000["dcom"][:2] / w < 1e-6).all()
@@ -103,7 +106,7 @@ class TestCopStabilizer(unittest.TestCase):
         self.arguments["actual_cop"][:2] = error2
         self.arguments["actual_com_vel"] = np.zeros(3)
         self.arguments["actual_com_acc"] = np.zeros(3)
-        desired = stab_loop(self.stab, self.arguments, 1)
+        desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
         self.assertTrue((desired["com"][:2] < error2).all())
         self.assertTrue(
@@ -113,7 +116,7 @@ class TestCopStabilizer(unittest.TestCase):
         n = desired["n"]
         self.assertTrue((np.abs(n) == 0).all())
 
-        desired_1000 = stab_loop(self.stab, self.arguments, 1000)
+        desired_1000 = stab_loop(self.stab, self.arguments, 1000, self.printing)
 
         self.assertTrue(
             (desired_1000["com"][:2] + desired_1000["dcom"][:2] / w < 1e-4).all()
@@ -126,7 +129,7 @@ class TestCopStabilizer(unittest.TestCase):
         self.arguments["actual_cop"][:2] = error3
         self.arguments["actual_com_vel"] = np.zeros(3)
         self.arguments["actual_com_acc"] = np.zeros(3)
-        desired = stab_loop(self.stab, self.arguments, 1)
+        desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
         self.assertTrue((desired["com"][:2] == error3).all())
         self.assertTrue((desired["cop"][:2] == error3).all())
@@ -134,7 +137,7 @@ class TestCopStabilizer(unittest.TestCase):
         n = desired["n"]
         self.assertTrue((np.abs(n) == 0).all())
 
-        desired_1000 = stab_loop(self.stab, self.arguments, 1000)
+        desired_1000 = stab_loop(self.stab, self.arguments, 1000, self.printing)
 
         self.assertTrue(
             (desired_1000["com"][:2] + desired_1000["dcom"][:2] / w == error3).all()
@@ -154,17 +157,21 @@ class TestCopStabilizer(unittest.TestCase):
         error = [0.02, 0.02]
         self.arguments["actual_com"][:2] = error
         self.arguments["actual_cop"][:2] = error
-        desired = stab_loop(self.stab, self.arguments, 1)
+        desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
-        self.assertTrue((desired["com"][:2] < error).all())
         self.assertTrue(
-            (desired["cop"][:2] > self.settings.cop_p_cc_gain * np.array(error)).all()
+            (desired["com"][:2] < error).all(),
+            msg=f"desired['com'][:2]={desired['com'][:2]}, error={error}"
+        )
+        self.assertTrue(
+            (desired["cop"][:2] > self.settings.cop_p_cc_gain * np.array(error)).all(),
+            msg=f"desired['cop'][:2]={desired['cop'][:2]}, expected>{self.settings.cop_p_cc_gain * np.array(error)}"
         )
 
         n = desired["n"]
         self.assertTrue((np.abs(n) == 0).all())
 
-        desired_1000 = stab_loop(self.stab, self.arguments, 1000)
+        desired_1000 = stab_loop(self.stab, self.arguments, 1000, self.printing)
 
         self.assertTrue(
             (
@@ -186,15 +193,16 @@ class TestCopStabilizer(unittest.TestCase):
         error = [0.02, 0.02]
         self.arguments["actual_com"][:2] = error
         self.arguments["actual_cop"][:2] = error
-        desired = stab_loop(self.stab, self.arguments, 1)
+        desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
-        self.assertTrue((desired["com"][:2] < error).all())
+        self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all(),
+                        f"cop: {desired['cop'][:2]}, com: {desired['com'][:2]}")
         self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all())
 
         n = desired["n"]
         self.assertTrue((np.abs(n) == 0).all())
 
-        desired_1000 = stab_loop(self.stab, self.arguments, 1000)
+        desired_1000 = stab_loop(self.stab, self.arguments, 1000, self.printing)
 
         self.assertTrue(
             (desired_1000["com"][:2] + desired_1000["dcom"][:2] / w < 1e-6).all()
@@ -207,7 +215,7 @@ class TestCopStabilizer(unittest.TestCase):
         self.arguments["actual_cop"][:2] = error2
         self.arguments["actual_com_vel"] = np.zeros(3)
         self.arguments["actual_com_acc"] = np.zeros(3)
-        desired = stab_loop(self.stab, self.arguments, 1)
+        desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
         self.assertTrue((desired["com"][:2] < error2).all())
         self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all())
@@ -215,7 +223,7 @@ class TestCopStabilizer(unittest.TestCase):
         n = desired["n"]
         self.assertTrue((np.abs(n) < 1e-15).all())
 
-        desired_1000 = stab_loop(self.stab, self.arguments, 1000)
+        desired_1000 = stab_loop(self.stab, self.arguments, 1000, self.printing)
 
         self.assertTrue(
             (desired_1000["com"][:2] + desired_1000["dcom"][:2] / w < 1e-5).all()
@@ -228,7 +236,7 @@ class TestCopStabilizer(unittest.TestCase):
         self.arguments["actual_cop"][:2] = error3
         self.arguments["actual_com_vel"] = np.zeros(3)
         self.arguments["actual_com_acc"] = np.zeros(3)
-        desired = stab_loop(self.stab, self.arguments, 1)
+        desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
         self.assertTrue((desired["com"][:2] == error3).all())
         self.assertTrue((desired["cop"][:2] == error3).all())
@@ -236,7 +244,7 @@ class TestCopStabilizer(unittest.TestCase):
         n = desired["n"]
         self.assertTrue((n == 0).all())
 
-        desired_1000 = stab_loop(self.stab, self.arguments, 1000)
+        desired_1000 = stab_loop(self.stab, self.arguments, 1000, self.printing)
 
         self.assertTrue(
             (desired_1000["com"][:2] + desired_1000["dcom"][:2] / w == error3).all()
@@ -257,15 +265,16 @@ class TestCopStabilizer(unittest.TestCase):
         error = [0.02, 0.02]
         self.arguments["actual_com"][:2] = error
         self.arguments["actual_cop"][:2] = error
-        desired = stab_loop(self.stab, self.arguments, 1)
+        desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
-        self.assertTrue((desired["com"][:2] < error).all())
+        self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all(),
+                        f"cop: {desired['cop'][:2]}, com: {desired['com'][:2]}")
         self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all())
 
         n = desired["n"]
         self.assertTrue((np.abs(n) < 1e-15).all())
 
-        desired_1000 = stab_loop(self.stab, self.arguments, 1000)
+        desired_1000 = stab_loop(self.stab, self.arguments, 1000, self.printing)
 
         self.assertTrue(
             (
@@ -306,13 +315,21 @@ def print_loop_results(results, arguments, w2, printing=False):
         print("B:   ", results[0][:2] - results[2][:2] / w2)
         print("CoP: ", results[6][:2])
         print(
-            "rCP: ",
+            "refCoPfromCoM: ",
             arguments["reference_com"][:2] - arguments["reference_com_acc"][:2] / w2,
         )
         print(
             "n:   ",
             np.hstack([results[6][:2] - results[0][:2] + results[2][:2] / w2, 0]),
         )
+        print("desired_com = ", results[0])
+        print("desired_com_vel = ", results[1])
+        print("desired_com_acc = ", results[2])
+        print("desired_icp = ", results[3])
+        print("actual_icp = ", results[4])
+        print("desired_cop_reference = ", results[5])
+        print("desired_cop_computed = ", results[6])
+        print("----------------------------")
 
 
 if __name__ == "__main__":

--- a/tests/python/test_cop_stabilizer.py
+++ b/tests/python/test_cop_stabilizer.py
@@ -16,7 +16,7 @@ import unittest
 unittest.util._MAX_LENGTH = 2000
 
 
-class TestCopStabilizer(unittest.TestCase):
+class TestCop3dStabilizer(unittest.TestCase):
     def setUp(self):
         self.printing = True
 
@@ -336,6 +336,24 @@ def print_loop_results(results, arguments, w2, printing=False):
         print("desired_cop_reference = ", results[5])
         print("desired_cop_computed = ", results[6])
         print("----------------------------")
+
+
+class TestCop2dStabilizer(TestCop3dStabilizer):
+    def setUp(self):
+        TestCop3dStabilizer.setUp(self)
+        self.arguments["actual_cop"] = np.zeros(2)
+
+    def test_constructor(self):
+        TestCop3dStabilizer.test_constructor(self)
+
+    def test_pcc_stabilization(self):
+        TestCop3dStabilizer.test_pcc_stabilization(self)
+
+    def test_pcc_stabilization_with_integral_term(self):
+        TestCop3dStabilizer.test_pcc_stabilization_with_integral_term(self)
+
+    def test_jccc_stabilization(self):
+        TestCop3dStabilizer.test_jccc_stabilization(self)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_cop_stabilizer.py
+++ b/tests/python/test_cop_stabilizer.py
@@ -84,8 +84,10 @@ class TestCopStabilizer(unittest.TestCase):
         self.arguments["actual_cop"][:2] = error
         desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
-        self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all(),
-                        f"cop: {desired['cop'][:2]}, com: {desired['com'][:2]}")
+        self.assertTrue(
+            (desired["cop"][:2] > desired["com"][:2]).all(),
+            f"cop: {desired['cop'][:2]}, com: {desired['com'][:2]}",
+        )
         self.assertTrue(
             (desired["cop"][:2] == self.settings.cop_p_cc_gain * np.array(error)).all()
         )
@@ -161,11 +163,11 @@ class TestCopStabilizer(unittest.TestCase):
 
         self.assertTrue(
             (desired["com"][:2] < error).all(),
-            msg=f"desired['com'][:2]={desired['com'][:2]}, error={error}"
+            msg=f"desired['com'][:2]={desired['com'][:2]}, error={error}",
         )
         self.assertTrue(
             (desired["cop"][:2] > self.settings.cop_p_cc_gain * np.array(error)).all(),
-            msg=f"desired['cop'][:2]={desired['cop'][:2]}, expected>{self.settings.cop_p_cc_gain * np.array(error)}"
+            msg=f"desired['cop'][:2]={desired['cop'][:2]}, expected>{self.settings.cop_p_cc_gain * np.array(error)}",
         )
 
         n = desired["n"]
@@ -195,8 +197,10 @@ class TestCopStabilizer(unittest.TestCase):
         self.arguments["actual_cop"][:2] = error
         desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
-        self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all(),
-                        f"cop: {desired['cop'][:2]}, com: {desired['com'][:2]}")
+        self.assertTrue(
+            (desired["cop"][:2] > desired["com"][:2]).all(),
+            f"cop: {desired['cop'][:2]}, com: {desired['com'][:2]}",
+        )
         self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all())
 
         n = desired["n"]
@@ -267,8 +271,10 @@ class TestCopStabilizer(unittest.TestCase):
         self.arguments["actual_cop"][:2] = error
         desired = stab_loop(self.stab, self.arguments, 1, self.printing)
 
-        self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all(),
-                        f"cop: {desired['cop'][:2]}, com: {desired['com'][:2]}")
+        self.assertTrue(
+            (desired["cop"][:2] > desired["com"][:2]).all(),
+            f"cop: {desired['cop'][:2]}, com: {desired['com'][:2]}",
+        )
         self.assertTrue((desired["cop"][:2] > desired["com"][:2]).all())
 
         n = desired["n"]


### PR DESCRIPTION
Copy from a commit from @pFernbach copied here.
The idea is to work with a 2D CoP object instead of 3D as usually only the X and Y component are used in controllers.
Main users only and current algorithm only use X and Y as far as I know.
Sorry the format does not make the review easy...
The idea is to change these kind of variable: `eVector3& desired_cop_reference` into `eVector2& desired_cop_reference`

Also make the configuration of the stabilizer a virtual method for more ease of use.