### PR TITLE
Migrate the unit-tests framework to doctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,6 @@ if(BUILD_TESTING)
       GIT_REPOSITORY https://github.com/doctest/doctest.git
       GIT_TAG master)
     FetchContent_MakeAvailable(doctest)
-    add_subdirectory(${doctest_SOURCE_DIR})
-    # Create an alias alled doctest::doctest of the doctest target.
-    add_library(doctest::doctest ALIAS doctest)
   endif()
   # Add extra dependencies in case the python interface is built.
   if(BUILD_PYTHON_INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ endif()
 
 # JRL-cmakemodule setup
 include("${JRL_CMAKE_MODULES}/base.cmake")
-include("${JRL_CMAKE_MODULES}/boost.cmake")
 
 # Project definition
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
@@ -48,15 +47,26 @@ project(${PROJECT_NAME} ${PROJECT_ARGS})
 
 # Project dependencies
 find_package(Eigen3 REQUIRED)
-
 if(BUILD_PYTHON_INTERFACE)
   find_package(eigenpy 2.7.12 REQUIRED)
   string(REGEX REPLACE "-" "_" PY_NAME ${PROJECT_NAME})
   set(${PY_NAME}_INSTALL_DIR ${PYTHON_SITELIB}/${PY_NAME})
 endif()
-
 if(BUILD_TESTING)
-  find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+  # Prepare doctest for other targets to use.
+  find_package(doctest QUIET)
+  if(NOT doctest_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+      doctest
+      GIT_REPOSITORY https://github.com/doctest/doctest.git
+      GIT_TAG master)
+    FetchContent_MakeAvailable(doctest)
+    add_subdirectory(${doctest_SOURCE_DIR})
+    # Create an alias alled doctest::doctest of the doctest target.
+    add_library(doctest::doctest ALIAS doctest)
+  endif()
+  # Add extra dependencies in case the python interface is built.
   if(BUILD_PYTHON_INTERFACE)
     find_package(pinocchio REQUIRED)
     find_package(example-robot-data REQUIRED)

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,11 @@
           packages = {
             default = self'.packages.biped-stabilizer;
             biped-stabilizer = pkgs.python3Packages.biped-stabilizer.overrideAttrs {
+              checkInputs = [
+                pkgs.doctest
+                pkgs.python3Packages.pinocchio
+                pkgs.python3Packages.example-robot-data
+              ];
               src = lib.fileset.toSource {
                 root = ./.;
                 fileset = lib.fileset.unions [

--- a/package.xml
+++ b/package.xml
@@ -13,14 +13,19 @@
 
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
-  <build_depend>eigen</build_depend>
+  
   <!-- The following tags are recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
-  <depend>boost</depend>
+  
   <depend>jrl_cmakemodules</depend>
+  <depend>eigen</depend>
+
+  <test_depend>doctest</test_depend>
+  <test_depend>pinocchio</test_depend>
+  <test_depend>example-robot-data</test_depend>
 
   <buildtool_depend>cmake</buildtool_depend>
   <export>

--- a/package.xml
+++ b/package.xml
@@ -13,13 +13,13 @@
 
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
-  
+
   <!-- The following tags are recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
-  
+
   <depend>jrl_cmakemodules</depend>
   <depend>eigen</depend>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_unit_test(test-biped-stabilizer-cpp cpp/test_cop_stabilizer.cpp)
 target_link_libraries(test-biped-stabilizer-cpp PUBLIC ${PROJECT_NAME})
-target_include_directories(test-biped-stabilizer-cpp
-                           PRIVATE doctest::doctest)
+target_include_directories(test-biped-stabilizer-cpp PRIVATE doctest::doctest)
 if(BUILD_PYTHON_INTERFACE)
   add_python_unit_test("test-biped-stabilizer-py"
                        "tests/python/test_cop_stabilizer.py" "python")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_unit_test(test_cop_stabilizer cpp/test_cop_stabilizer.cpp)
-target_link_libraries(test_cop_stabilizer PUBLIC ${PROJECT_NAME})
-target_include_directories(test_cop_stabilizer
-                           PRIVATE Boost::unit_test_framework)
+add_unit_test(test-biped-stabilizer-cpp cpp/test_cop_stabilizer.cpp)
+target_link_libraries(test-biped-stabilizer-cpp PUBLIC ${PROJECT_NAME})
+target_include_directories(test-biped-stabilizer-cpp
+                           PRIVATE doctest::doctest)
 if(BUILD_PYTHON_INTERFACE)
-  add_python_unit_test("test_cop_stabilizer_py"
+  add_python_unit_test("test-biped-stabilizer-py"
                        "tests/python/test_cop_stabilizer.py" "python")
 endif()

--- a/tests/cpp/test_cop_stabilizer.cpp
+++ b/tests/cpp/test_cop_stabilizer.cpp
@@ -1,13 +1,10 @@
-#define BOOST_TEST_MODULE biped_stabilizer test boost
-#include <boost/test/included/unit_test.hpp>
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"
 
 #include "biped-stabilizer/cop_stabilizer.hpp"
 
-BOOST_AUTO_TEST_CASE(test_default_constructor) {
+TEST_CASE("FlexEstimatorTest - DefaultConstructor") {
   biped_stabilizer::CopStabilizer stabilizer;
   biped_stabilizer::CopStabilizerSettings default_settings;
-  BOOST_CHECK(true);
-  BOOST_CHECK(default_settings == stabilizer.getSettings());
+  CHECK(default_settings == stabilizer.getSettings());
 }
-
-BOOST_AUTO_TEST_CASE(test_dummy_2) { BOOST_CHECK(true); }


### PR DESCRIPTION
The rational behind this breaking change is to use a lightweight and efficient C++ unit-test framework.

- boost.unittest current integration was buggy. I drags quite a bit of dependencies as well.
- GTest is overly complex and drags too much dependencies.
- doctest: https://github.com/doctest/doctest/ seemed to be a reasonable choice.

In this PR I am updating the unit-test and the local nix configuration in order to use doctest.