### PR TITLE
Fix C++ build (no bindings) on alum a robot OS which treats compilation warning as errors

### DIFF
--- a/include/biped-stabilizer/cop_stabilizer.hpp
+++ b/include/biped-stabilizer/cop_stabilizer.hpp
@@ -48,7 +48,7 @@ public:
   bool saturate_cop = true;
   bool use_rate_limited_dcm = false;
 
-  bool operator==(const CopStabilizerSettings &rhs) {
+  bool operator==(const CopStabilizerSettings &rhs) const {
     bool test = true;
     test &= this->height == rhs.height;
     test &= this->foot_length == rhs.foot_length;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,8 @@
 if(NOT BUILD_STANDALONE_PYTHON_INTERFACE)
   add_unit_test(test-biped-stabilizer-cpp cpp/test_cop_stabilizer.cpp)
-  target_link_libraries(test-biped-stabilizer-cpp PUBLIC ${PROJECT_NAME})
-  target_include_directories(test-biped-stabilizer-cpp PRIVATE doctest::doctest)
+  target_link_libraries(test-biped-stabilizer-cpp PUBLIC ${PROJECT_NAME}
+                                                         doctest::doctest)
 endif()
-
 if(BUILD_PYTHON_INTERFACE)
   add_python_unit_test("test-biped-stabilizer-py"
                        "tests/python/test_cop_stabilizer.py" "python")


### PR DESCRIPTION
For some reason the CI in nix did not catch that.
@nim65s could you check if you can see why?