### PR TITLE
Add the python dependencies to the package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,11 @@
   <depend>jrl_cmakemodules</depend>
   <depend>eigen</depend>
 
+  <!-- Python dependencies. -->
+  <depend>eigenpy</depend>
+  <depend>pinocchio</depend>
+  <depend>example-robot-data</depend>
+
   <test_depend>doctest</test_depend>
   <test_depend>pinocchio</test_depend>
   <test_depend>example-robot-data</test_depend>


### PR DESCRIPTION
I guess this is also missing here.
As jrl-cmakemodules build the python bindings by default. We need to add the dependencies in the package.xml to have a successful ROS build